### PR TITLE
Add mobile_context 1-0-1 with networkType and networkTechnology

### DIFF
--- a/schemas/com.snowplowanalytics.snowplow/mobile_context/jsonschema/1-0-1
+++ b/schemas/com.snowplowanalytics.snowplow/mobile_context/jsonschema/1-0-1
@@ -28,6 +28,9 @@
 		"networkType": {
 				"enum": [ "mobile", "wifi"]
 		},
+		"networkTechnology": {
+				"type": "string"
+    },
 		"openIdfa": {
 			"type": "string"
 		},

--- a/schemas/com.snowplowanalytics.snowplow/mobile_context/jsonschema/1-0-1
+++ b/schemas/com.snowplowanalytics.snowplow/mobile_context/jsonschema/1-0-1
@@ -1,0 +1,49 @@
+{
+	"$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+	"description": "Schema for mobile contexts",
+	"self": {
+		"vendor": "com.snowplowanalytics.snowplow",
+		"name": "mobile_context",
+		"format": "jsonschema",
+		"version": "1-0-0"
+	},
+
+	"type": "object",
+	"properties": {
+		"osType": {
+			"type": "string"
+		},
+		"osVersion": {
+			"type": "string"
+		},
+		"osFlavor": {
+		    "type": "string"
+		},
+		"deviceManufacturer": {
+			"type": "string"
+		},
+		"deviceModel": {
+			"type": "string"
+		},
+		"carrier": {
+			"type": "string"
+		},
+		"networkType": {
+		    "type": "string"
+		},
+		"openIdfa": {
+			"type": "string"
+		},
+		"appleIdfa": {
+			"type": "string"
+		},
+		"appleIdfv": {
+			"type": "string"
+		},
+		"androidIdfa": {
+			"type": "string"
+		}
+	},
+	"required": ["osType", "osVersion", "deviceManufacturer", "deviceModel"],
+	"additionalProperties": false
+}

--- a/schemas/com.snowplowanalytics.snowplow/mobile_context/jsonschema/1-0-1
+++ b/schemas/com.snowplowanalytics.snowplow/mobile_context/jsonschema/1-0-1
@@ -16,7 +16,7 @@
 		"osVersion": {
 			"type": "string"
 		},
-		"osFlavor": {
+		"buildFlavor": {
 		    "type": "string"
 		},
 		"deviceManufacturer": {

--- a/schemas/com.snowplowanalytics.snowplow/mobile_context/jsonschema/1-0-1
+++ b/schemas/com.snowplowanalytics.snowplow/mobile_context/jsonschema/1-0-1
@@ -16,9 +16,6 @@
 		"osVersion": {
 			"type": "string"
 		},
-		"androidFlavor": {
-		    "type": "string"
-		},
 		"deviceManufacturer": {
 			"type": "string"
 		},

--- a/schemas/com.snowplowanalytics.snowplow/mobile_context/jsonschema/1-0-1
+++ b/schemas/com.snowplowanalytics.snowplow/mobile_context/jsonschema/1-0-1
@@ -26,7 +26,7 @@
 			"type": "string"
 		},
 		"networkType": {
-		    "type": "string"
+				"enum": [ "mobile", "wifi"]
 		},
 		"openIdfa": {
 			"type": "string"

--- a/schemas/com.snowplowanalytics.snowplow/mobile_context/jsonschema/1-0-1
+++ b/schemas/com.snowplowanalytics.snowplow/mobile_context/jsonschema/1-0-1
@@ -5,7 +5,7 @@
 		"vendor": "com.snowplowanalytics.snowplow",
 		"name": "mobile_context",
 		"format": "jsonschema",
-		"version": "1-0-0"
+		"version": "1-0-1"
 	},
 
 	"type": "object",
@@ -16,7 +16,7 @@
 		"osVersion": {
 			"type": "string"
 		},
-		"buildFlavor": {
+		"androidFlavor": {
 		    "type": "string"
 		},
 		"deviceManufacturer": {


### PR DESCRIPTION
A proposed version bump to include both a field for Android flavors (distinct builds for different stores, locales, etc) as well as network types (3G, LTE, WiFi).

I put this into a distinct version file following the established pattern. I hope that’s OK. 

The diff is:

```
18a19,21
> 		"buildFlavor": {
> 		    "type": "string"
> 		},
27a31,33
> 		"networkType": {
> 		    "type": "string"
> 		},
```

Does this make sense? Is it something you’d be interested in?