### PR TITLE
Adding "none" for network type

### DIFF
--- a/schemas/com.snowplowanalytics.snowplow/mobile_context/jsonschema/1-0-1
+++ b/schemas/com.snowplowanalytics.snowplow/mobile_context/jsonschema/1-0-1
@@ -26,7 +26,7 @@
 			"type": "string"
 		},
 		"networkType": {
-				"enum": [ "mobile", "wifi"]
+				"enum": [ "mobile", "wifi", "none"]
 		},
 		"networkTechnology": {
 				"type": "string"

--- a/schemas/com.snowplowanalytics.snowplow/mobile_context/jsonschema/1-0-1
+++ b/schemas/com.snowplowanalytics.snowplow/mobile_context/jsonschema/1-0-1
@@ -28,6 +28,9 @@
 		"networkType": {
 				"enum": [ "mobile", "wifi"]
 		},
+		"networkTechnology": {
+				"type": "string"
+    },
 		"openIdfa": {
 			"type": "string"
 		},

--- a/schemas/com.snowplowanalytics.snowplow/mobile_context/jsonschema/1-0-1
+++ b/schemas/com.snowplowanalytics.snowplow/mobile_context/jsonschema/1-0-1
@@ -1,0 +1,49 @@
+{
+	"$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+	"description": "Schema for mobile contexts",
+	"self": {
+		"vendor": "com.snowplowanalytics.snowplow",
+		"name": "mobile_context",
+		"format": "jsonschema",
+		"version": "1-0-0"
+	},
+
+	"type": "object",
+	"properties": {
+		"osType": {
+			"type": "string"
+		},
+		"osVersion": {
+			"type": "string"
+		},
+		"osFlavor": {
+		    "type": "string"
+		},
+		"deviceManufacturer": {
+			"type": "string"
+		},
+		"deviceModel": {
+			"type": "string"
+		},
+		"carrier": {
+			"type": "string"
+		},
+		"networkType": {
+		    "type": "string"
+		},
+		"openIdfa": {
+			"type": "string"
+		},
+		"appleIdfa": {
+			"type": "string"
+		},
+		"appleIdfv": {
+			"type": "string"
+		},
+		"androidIdfa": {
+			"type": "string"
+		}
+	},
+	"required": ["osType", "osVersion", "deviceManufacturer", "deviceModel"],
+	"additionalProperties": false
+}

--- a/schemas/com.snowplowanalytics.snowplow/mobile_context/jsonschema/1-0-1
+++ b/schemas/com.snowplowanalytics.snowplow/mobile_context/jsonschema/1-0-1
@@ -16,7 +16,7 @@
 		"osVersion": {
 			"type": "string"
 		},
-		"osFlavor": {
+		"buildFlavor": {
 		    "type": "string"
 		},
 		"deviceManufacturer": {

--- a/schemas/com.snowplowanalytics.snowplow/mobile_context/jsonschema/1-0-1
+++ b/schemas/com.snowplowanalytics.snowplow/mobile_context/jsonschema/1-0-1
@@ -26,7 +26,7 @@
 			"type": "string"
 		},
 		"networkType": {
-				"enum": [ "mobile", "wifi", "none"]
+				"enum": [ "mobile", "wifi"]
 		},
 		"networkTechnology": {
 				"type": "string"

--- a/schemas/com.snowplowanalytics.snowplow/mobile_context/jsonschema/1-0-1
+++ b/schemas/com.snowplowanalytics.snowplow/mobile_context/jsonschema/1-0-1
@@ -16,9 +16,6 @@
 		"osVersion": {
 			"type": "string"
 		},
-		"androidFlavor": {
-		    "type": "string"
-		},
 		"deviceManufacturer": {
 			"type": "string"
 		},

--- a/schemas/com.snowplowanalytics.snowplow/mobile_context/jsonschema/1-0-1
+++ b/schemas/com.snowplowanalytics.snowplow/mobile_context/jsonschema/1-0-1
@@ -26,7 +26,7 @@
 			"type": "string"
 		},
 		"networkType": {
-		    "type": "string"
+				"enum": [ "mobile", "wifi"]
 		},
 		"openIdfa": {
 			"type": "string"

--- a/schemas/com.snowplowanalytics.snowplow/mobile_context/jsonschema/1-0-1
+++ b/schemas/com.snowplowanalytics.snowplow/mobile_context/jsonschema/1-0-1
@@ -5,7 +5,7 @@
 		"vendor": "com.snowplowanalytics.snowplow",
 		"name": "mobile_context",
 		"format": "jsonschema",
-		"version": "1-0-0"
+		"version": "1-0-1"
 	},
 
 	"type": "object",
@@ -16,7 +16,7 @@
 		"osVersion": {
 			"type": "string"
 		},
-		"buildFlavor": {
+		"androidFlavor": {
 		    "type": "string"
 		},
 		"deviceManufacturer": {


### PR DESCRIPTION
While implementing this in ObjC, I realized that there are times when events will get generated when there's no network connection. Ergo, we need a none. 

I'm not quite sure how to attach a new PR to a closed one that's part of a Milestone—so this one seems have bundled up the full set of changes.