### PR TITLE
Added com.snowplowanalytics.iglu/resolver-config/jsonschema/1-0-1 with apikey

### DIFF
--- a/schemas/com.snowplowanalytics.iglu/resolver-config/jsonschema/1-0-1
+++ b/schemas/com.snowplowanalytics.iglu/resolver-config/jsonschema/1-0-1
@@ -1,0 +1,93 @@
+{
+	"$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+	"description": "Schema for an Iglu resolver's configuration",
+	"self": {
+		"vendor": "com.snowplowanalytics.iglu",
+		"name": "resolver-config",
+		"format": "jsonschema",
+		"version": "1-0-1"
+	},
+	
+	"type": "object",
+
+	"properties": {
+
+		"cacheSize": {
+			"type": "number"
+		},
+
+		"repositories": {
+			"type": "array",
+			"items": {
+				"type": "object",
+
+				"properties": {
+
+					"name": {
+						"type": "string"
+					},
+
+					"priority": {
+						"type": "number"
+					},
+
+					"vendorPrefixes": {
+						"type": "array",
+						"items": {
+							"type": "string"
+						}
+					},
+
+					"connection": {
+						"type": "object",
+						"oneOf": [
+							{
+								"properties": {
+									"embedded": {
+										"type": "object",
+										"properties": {
+											"path": {
+												"type": "string"
+											}
+										},
+										"required": ["path"],
+										"additionalProperties": false
+									}
+								},
+								"required": ["embedded"],
+								"additionalProperties": false
+							},
+							{
+								"properties": {
+									"http": {
+										"type": "object",
+										"properties": {
+											"uri": {
+												"type": "string",
+												"format": "uri"
+											},
+											"apikey": {
+												"type": "string"
+											}
+										},
+										"required": ["uri"],
+										"additionalProperties": false
+									}
+								},
+								"required": ["http"],
+								"additionalProperties": false
+							}
+						]
+					}
+				},
+				"required": ["name", "priority", "vendorPrefixes", "connection"],
+				"additionalProperties": false
+			}
+		}
+
+	},
+
+	"required": ["cacheSize", "repositories"],
+	"additionalProperties": false
+}
+


### PR DESCRIPTION
@alexanderdean could you take a look? I decided to not add `format: uuid` because it can be misleading. JSON Schema validate it with regex including capitals, while for iglu scala repository capitals will be illegal.