### PR TITLE
Allow for users to pass additional metadata with their Mandrill events

### DIFF
--- a/schemas/com.mandrill/message_bounced/jsonschema/1-0-0
+++ b/schemas/com.mandrill/message_bounced/jsonschema/1-0-0
@@ -41,7 +41,7 @@
 							"type": "number"
 						}
 					},
-					"additionalProperties": false
+					"additionalProperties": true
 				},
 				"sender": {
 					"type": "string"

--- a/schemas/com.mandrill/message_clicked/jsonschema/1-0-0
+++ b/schemas/com.mandrill/message_clicked/jsonschema/1-0-0
@@ -90,7 +90,7 @@
 							"type": "number"
 						}
 					},
-					"additionalProperties": false
+					"additionalProperties": true
 				},
 				"opens": {
 					"type": "array",

--- a/schemas/com.mandrill/message_delayed/jsonschema/1-0-0
+++ b/schemas/com.mandrill/message_delayed/jsonschema/1-0-0
@@ -35,7 +35,7 @@
 							"type": "number"
 						}
 					},
-					"additionalProperties": false
+					"additionalProperties": true
 				},
 				"opens": {
 					"type": "array"

--- a/schemas/com.mandrill/message_marked_as_spam/jsonschema/1-0-0
+++ b/schemas/com.mandrill/message_marked_as_spam/jsonschema/1-0-0
@@ -48,7 +48,7 @@
 							"type": "number"
 						}
 					},
-					"additionalProperties": false
+					"additionalProperties": true
 				},
 				"opens": {
 					"type": "array",

--- a/schemas/com.mandrill/message_opened/jsonschema/1-0-0
+++ b/schemas/com.mandrill/message_opened/jsonschema/1-0-0
@@ -90,7 +90,7 @@
 							"type": "number"
 						}
 					},
-					"additionalProperties": false
+					"additionalProperties": true
 				},
 				"opens": {
 					"type": "array",

--- a/schemas/com.mandrill/message_rejected/jsonschema/1-0-0
+++ b/schemas/com.mandrill/message_rejected/jsonschema/1-0-0
@@ -35,7 +35,7 @@
 							"type": "number"
 						}
 					},
-					"additionalProperties": false
+					"additionalProperties": true
 				},
 				"opens": {
 					"type": "array"

--- a/schemas/com.mandrill/message_sent/jsonschema/1-0-0
+++ b/schemas/com.mandrill/message_sent/jsonschema/1-0-0
@@ -35,7 +35,7 @@
 							"type": "number"
 						}
 					},
-					"additionalProperties": false
+					"additionalProperties": true
 				},
 				"opens": {
 					"type": "array"

--- a/schemas/com.mandrill/message_soft_bounced/jsonschema/1-0-0
+++ b/schemas/com.mandrill/message_soft_bounced/jsonschema/1-0-0
@@ -41,7 +41,7 @@
 							"type": "number"
 						}
 					},
-					"additionalProperties": false
+					"additionalProperties": true
 				},
 				"sender": {
 					"type": "string"


### PR DESCRIPTION
We've seen from one of our clients that it's possible to create your own additional metadata fields in Mandirll. When this is done that additional data is included as extra properties in the metadata object. Previously this object had `additionalProperties` set to `False`. This PR patches that so that they're set to true - preventing the events from failing validation for users who have setup their own metadata fields.

