### PR TITLE
Patch com.snowplowanalytics.iglu/jsonschema/resolver-config to forbid invalid priority and cacheSize

### DIFF
--- a/schemas/com.snowplowanalytics.iglu/resolver-config/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.iglu/resolver-config/jsonschema/1-0-0
@@ -7,13 +7,14 @@
 		"format": "jsonschema",
 		"version": "1-0-0"
 	},
-	
+
 	"type": "object",
 
 	"properties": {
 
 		"cacheSize": {
-			"type": "number"
+			"type": "integer",
+ 			"minimum": 0
 		},
 
 		"repositories": {
@@ -28,7 +29,7 @@
 					},
 
 					"priority": {
-						"type": "number"
+						"type": "integer"
 					},
 
 					"vendorPrefixes": {

--- a/schemas/com.snowplowanalytics.iglu/resolver-config/jsonschema/1-0-1
+++ b/schemas/com.snowplowanalytics.iglu/resolver-config/jsonschema/1-0-1
@@ -7,13 +7,14 @@
 		"format": "jsonschema",
 		"version": "1-0-1"
 	},
-	
+
 	"type": "object",
 
 	"properties": {
 
 		"cacheSize": {
-			"type": "number"
+			"type": "integer",
+ 			"minimum": 0
 		},
 
 		"repositories": {
@@ -28,7 +29,7 @@
 					},
 
 					"priority": {
-						"type": "number"
+						"type": "integer"
 					},
 
 					"vendorPrefixes": {


### PR DESCRIPTION
This PR patches both resolver-config Schemas to restrict priority and cacheSize to integer and also sets cacheSize minimum to 0.