### PR TITLE
Patch com.amazon.aws.lambda/s3_notification_event/jsonschema/1-0-0

### DIFF
--- a/schemas/com.amazon.aws.lambda/s3_notification_event/jsonschema/1-0-0
+++ b/schemas/com.amazon.aws.lambda/s3_notification_event/jsonschema/1-0-0
@@ -59,7 +59,6 @@
 								"integer",
 								"null"
 							],
-							"maximum": 32767,
 							"minimum": 0
 						},
 						"eTag": {


### PR DESCRIPTION
Remove upper limit on 'size' field as this is in bytes