### PR TITLE
Add elementContent to JSON path and schema

### DIFF
--- a/jsonpaths/com.snowplowanalytics.snowplow/link_click_1.json
+++ b/jsonpaths/com.snowplowanalytics.snowplow/link_click_1.json
@@ -15,6 +15,7 @@
     "$.data.elementId",
     "$.data.elementClasses",
     "$.data.elementTarget",
-    "$.data.targetUrl"
+    "$.data.targetUrl",
+    "$.data.elementContent"
     ]
 }

--- a/sql/com.snowplowanalytics.snowplow/link_click_1.sql
+++ b/sql/com.snowplowanalytics.snowplow/link_click_1.sql
@@ -13,7 +13,7 @@
 -- Copyright:     Copyright (c) 2014 Snowplow Analytics Ltd
 -- License:       Apache License Version 2.0
 --
--- Compatibility: iglu:com.snowplowanalytics.snowplow/link_click/jsonschema/1-0-0
+-- Compatibility: iglu:com.snowplowanalytics.snowplow/link_click/jsonschema/1-0-1
 
 CREATE TABLE atomic.com_snowplowanalytics_snowplow_link_click_1 (
 	-- Schema of this type
@@ -32,6 +32,7 @@ CREATE TABLE atomic.com_snowplowanalytics_snowplow_link_click_1 (
 	element_classes varchar(2048) encode raw, -- Holds a JSON array. TODO: will replace with a ref_ following https://github.com/snowplow/snowplow/issues/647
 	element_target  varchar(255)  encode text255,
 	target_url      varchar(4096) encode text32k not null,
+	element_content varchar(255)  encode text255,
 	FOREIGN KEY(root_id) REFERENCES atomic.events(event_id)
 )
 DISTSTYLE KEY


### PR DESCRIPTION
Element content is missing from the JSON path and schema for link_click_1. This property was added in the 1-0-1 [JSON schema](https://github.com/snowplow/iglu-central/blob/edb500bd34eabdd41684e16d1698f0bae6baa8b7/schemas/com.snowplowanalytics.snowplow/link_click/jsonschema/1-0-1).

I've set the length at 255 but happy to change to whatever would be more appropriate.