### PR TITLE
Add Sauna command schemas & HipChat responder schema/avro

### DIFF
--- a/schemas/com.hipchat.sauna.commands/send_room_notification/jsonschema/1-0-0
+++ b/schemas/com.hipchat.sauna.commands/send_room_notification/jsonschema/1-0-0
@@ -1,0 +1,47 @@
+{
+    "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+    "description": "Schema for a Hipchat room notification command",
+    "self":{
+        "vendor": "com.hipchat.sauna.commands",
+        "name": "send_room_notification",
+        "format": "jsonschema",
+        "version": "1-0-0"
+    },
+    "type": "object",
+    "properties": {
+        "roomIdOrName": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 100
+        },
+        "color": {
+            "enum": [
+                "YELLOW",
+                "GREEN",
+                "RED",
+                "PURPLE",
+                "GRAY",
+                "RANDOM"
+            ]
+        },
+        "message": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 10000
+        },
+        "notify": {
+            "type": "boolean"
+        },
+        "messageFormat": {
+            "enum": [
+                "HTML",
+                "TEXT"
+            ]
+        }
+    },
+    "required": [
+        "roomIdOrName",
+        "message"
+    ],
+    "additionalProperties": false
+}

--- a/schemas/com.snowplowanalytics.sauna.commands/command/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.sauna.commands/command/jsonschema/1-0-0
@@ -1,0 +1,24 @@
+{
+    "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+    "description": "Schema for a Sauna command",
+    "self": {
+        "vendor": "com.snowplowanalytics.sauna.commands",
+        "name": "command",
+        "format": "jsonschema",
+        "version": "1-0-0"
+    },
+    "type": "object",
+    "properties": {
+        "envelope": {
+            "$ref": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/instance-iglu-only/jsonschema/1-0-0#"
+        },
+        "command": {
+            "$ref": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/instance-iglu-only/jsonschema/1-0-0#"
+        }
+    },
+    "required": [
+        "envelope",
+        "command"
+    ],
+    "additionalProperties": false
+}

--- a/schemas/com.snowplowanalytics.sauna.commands/envelope/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.sauna.commands/envelope/jsonschema/1-0-0
@@ -1,0 +1,55 @@
+{
+    "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+    "description": "Schema for a Sauna command's envelope",
+    "self": {
+        "vendor": "com.snowplowanalytics.sauna.commands",
+        "name": "envelope",
+        "format": "jsonschema",
+        "version": "1-0-0"
+    },
+    "type": "object",
+    "properties": {
+        "commandId": {
+            "type": "string",
+            "format": "uuid"
+        },
+        "whenCreated": {
+            "type": "string",
+            "format": "date-time"
+        },
+        "execution": {
+            "type": "object",
+            "properties": {
+                "semantics": {
+                    "enum": [
+                        "AT_LEAST_ONCE"
+                    ]
+                },
+                "timeToLive": {
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                }
+            },
+            "required": [
+                "semantics",
+                "timeToLive"
+            ],
+            "additionalProperties": false
+        },
+        "tags": {
+            "type": "object",
+            "additionalProperties": {
+                "type": "string"
+            }
+        }
+    },
+    "required": [
+        "commandId",
+        "whenCreated",
+        "execution",
+        "tags"
+    ],
+    "additionalProperties": false
+}

--- a/schemas/com.snowplowanalytics.sauna.responders/HipchatConfig/avro/1-0-0
+++ b/schemas/com.snowplowanalytics.sauna.responders/HipchatConfig/avro/1-0-0
@@ -1,0 +1,28 @@
+{
+    "namespace": "com.snowplowanalytics.sauna.responders",
+    "name": "HipchatConfig",
+    "type": "record",
+    "fields": [
+        {
+            "name": "enabled",
+            "type": "boolean"
+        },
+        {
+            "name": "id",
+            "type": "string"
+        },
+        {
+            "name": "parameters",
+            "type": {
+                "name": "HipchatConfigParameters",
+                "type": "record",
+                "fields": [
+                    {
+                        "name": "authToken",
+                        "type": "string"
+                    }
+                ]
+            }
+        }
+    ]
+}


### PR DESCRIPTION
This PR adds the following schemas:

- **com.snowplowanalytics.sauna.commands/command/jsonschema/1-0-0** - a JSON schema for a Sauna command. Represented by a self-describing JSON which itself contains two self-describing JSONs - note the schemas for both `envelope` and `command` only accept Iglu-based sources.
  - https://github.com/snowplow/sauna/wiki/Commands-for-analysts#anatomy-of-a-command
- **com.snowplowanalytics.sauna.commands/envelope/jsonschema/1-0-0** - a JSON schema for a Sauna command's envelope, which identifies the command and contains execution-related metadata.
  - https://github.com/snowplow/sauna/wiki/Commands-for-analysts#anatomy-of-a-command
- **com.hipchat.sauna.commands/send_room_notification/jsonschema/1-0-0** - a JSON schema example of a Sauna command's action to be used for the HipChat Sauna responder.
  - Source: https://github.com/snowplow/sauna/wiki/HipChat-Responder-user-guide#213-example-command
- **com.snowplowanalytics.sauna.responders/HipchatConfig/avro/1-0-0** - an Avro configuration for the HipChat Sauna responder.
  - Source: https://github.com/snowplow/sauna/wiki/HipChat-Responder-setup-guide