### PR TITLE
Making the JSONPaths for mobile_context reflect 1-0-1

### DIFF
--- a/jsonpaths/com.snowplowanalytics.snowplow/mobile_context_1.json
+++ b/jsonpaths/com.snowplowanalytics.snowplow/mobile_context_1.json
@@ -17,6 +17,8 @@
     "$.data.deviceManufacturer",
     "$.data.deviceModel",
     "$.data.carrier",
+    "$.data.networkType",
+    "$.data.networkTechnology",
     "$.data.openIdfa",
     "$.data.appleIdfa",
     "$.data.appleIdfv",


### PR DESCRIPTION
@alexanderdean @jbeemster This seems to be breaking the Storage Loader on Android Tracker 0.6.x

Related question: How should we handle JSONPaths when events come in both `1-0-0` and `1-0-1` formats? e.g. 50% of the user base that still haven't updated the app and are still in version 0.5.x