### PR TITLE
Fix/mandrill subaccount

### DIFF
--- a/schemas/com.mandrill/message_bounced/jsonschema/1-0-1
+++ b/schemas/com.mandrill/message_bounced/jsonschema/1-0-1
@@ -1,0 +1,111 @@
+{
+	"$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+	"description": "Schema for a Mandrill hard bounce event",
+	"self": {
+		"vendor": "com.mandrill",
+		"name": "message_bounced",
+		"format": "jsonschema",
+		"version": "1-0-0"
+	},
+
+	"type": "object",
+	"properties": {
+		"_id": {
+			"type": "string"
+		},
+		"msg": {
+			"type": "object",
+			"properties": {
+				"_id": {
+					"type": "string"
+				},
+				"_version": {
+					"type": "string"
+				},
+				"bgtools_code": {
+					"type": "number"
+				},
+				"bounce_description": {
+					"type": "string"
+				},
+				"diag": {
+					"type": "string"
+				},
+				"email": {
+					"type": "string"
+				},
+				"metadata": {
+					"type": "object",
+					"properties": {
+						"user_id": {
+							"type": "number"
+						}
+					},
+					"additionalProperties": true
+				},
+				"sender": {
+					"type": "string"
+				},
+				"state": {
+					"type": "string"
+				},
+				"subaccount": {
+					"type": ["string", "null"]
+				},
+				"subject": {
+					"type": "string"
+				},
+				"tags": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"ts": {
+					"type": "string",
+					"format": "date-time"
+				},
+				"smtp_events": {
+					"type": "array",
+					"items": {
+						"type": "object",
+						"properties": {
+							"ts": {
+								"type": "string",
+								"format": "date-time"
+							},
+							"type": {
+								"type": "string"
+							},
+							"diag": {
+								"type": "string"
+							},
+							"source_ip": {
+								"type": "string"
+							},
+							"destination_ip": {
+								"type": "string"
+							},
+							"size": {
+								"type": "integer"
+							}					
+						},
+						"additionalProperties": true
+					}
+				},
+				"resends": {
+					"type": "array"
+				},
+				"template": {
+					"type": ["string", "null"]
+				}
+			},
+			"additionalProperties": false
+		},
+		"ts": {
+			"type": "string",
+			"format": "date-time"
+		}
+	},
+	"additionalProperties": false
+}

--- a/schemas/com.mandrill/message_bounced/jsonschema/1-0-1
+++ b/schemas/com.mandrill/message_bounced/jsonschema/1-0-1
@@ -5,7 +5,7 @@
 		"vendor": "com.mandrill",
 		"name": "message_bounced",
 		"format": "jsonschema",
-		"version": "1-0-0"
+		"version": "1-0-1"
 	},
 
 	"type": "object",

--- a/schemas/com.mandrill/message_clicked/jsonschema/1-0-1
+++ b/schemas/com.mandrill/message_clicked/jsonschema/1-0-1
@@ -1,0 +1,239 @@
+{
+	"$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+	"description": "Schema for a Mandrill message clicked event",
+	"self": {
+		"vendor": "com.mandrill",
+		"name": "message_clicked",
+		"format": "jsonschema",
+		"version": "1-0-0"
+	},
+
+	"type": "object",
+	"properties": {
+		"_id": {
+			"type": "string"
+		},
+		"ip": {
+			"type": "string"
+		},
+		"location": {
+			"type": "object",
+			"properties": {
+				"city": {
+					"type": "string"
+				},
+				"country_short": {
+					"type": "string"
+				},
+				"country": {
+					"type": "string"
+				},
+				"latitude": {
+					"type": "number"
+				},
+				"longitude": {
+					"type": "number"
+				},
+				"postal_code": {
+					"type": "string"
+				},
+				"region": {
+					"type": "string"
+				},
+				"timezone": {
+					"type": "string"
+				}
+			},
+			"additionalProperties": false
+		},
+		"msg": {
+			"type": "object",
+			"properties": {
+				"_id": {
+					"type": "string"
+				},
+				"_version": {
+					"type": "string"
+				},
+				"clicks": {
+					"type": "array",
+					"items": {
+						"type": "object",
+						"properties": {
+							"ts": {
+								"type": "string",
+								"format": "date-time"
+							},
+							"url": {
+								"type": "string"
+							},
+							"ip": {
+								"type": "string"
+							},
+							"location": {
+								"type": ["string", "null"]
+							},
+							"ua": {
+								"type": "string"
+							}
+						},
+						"additionalProperties": true
+					}
+				},
+				"email": {
+					"type": "string"
+				},
+				"metadata": {
+					"type": "object",
+					"properties": {
+						"user_id": {
+							"type": "number"
+						}
+					},
+					"additionalProperties": true
+				},
+				"opens": {
+					"type": "array",
+					"items": {
+						"type": "object",
+						"properties": {
+							"ts": {
+								"type": "string",
+								"format": "date-time"
+							},
+							"ip": {
+								"type": "string"
+							},
+							"location": {
+								"type": ["string", "null"]
+							},
+							"ua": {
+								"type": "string"
+							}
+						},
+						"additionalProperties": true
+					}
+				},
+				"sender": {
+					"type": "string"
+				},
+				"state": {
+					"type": "string"
+				},
+				"subaccount": {
+					"type": ["string", "null"]
+				},
+				"subject": {
+					"type": "string"
+				},
+				"tags": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"ts": {
+					"type": "string",
+					"format": "date-time"
+				},
+				"resends": {
+					"type": "array"
+				},
+				"smtp_events": {
+					"type": "array",
+					"items": {
+						"type": "object",
+						"properties": {
+							"ts": {
+								"type": "string",
+								"format": "date-time"
+							},
+							"type": {
+								"type": "string"
+							},
+							"diag": {
+								"type": "string"
+							},
+							"source_ip": {
+								"type": "string"
+							},
+							"destination_ip": {
+								"type": "string"
+							},
+							"size": {
+								"type": "integer"
+							}					
+						},
+						"additionalProperties": true
+					}
+				},
+				"template": {
+					"type": ["string", "null"]
+				}
+			},
+			"additionalProperties": false
+		},
+		"ts": {
+			"type": "string",
+			"format": "date-time"
+		},
+		"url": {
+			"type": "string"
+		},
+		"user_agent_parsed": {
+			"type": "object",
+			"properties": {
+				"mobile": {
+					"type": "boolean"
+				},
+				"os_company_url": {
+					"type": "string"
+				},
+				"os_company": {
+					"type": "string"
+				},
+				"os_family": {
+					"type": "string"
+				},
+				"os_icon": {
+					"type": "string"
+				},
+				"os_name": {
+					"type": "string"
+				},
+				"os_url": {
+					"type": "string"
+				},
+				"type": {
+					"type": "string"
+				},
+				"ua_company_url": {
+					"type": "string"
+				},
+				"ua_company": {
+					"type": "string"
+				},
+				"ua_family": {
+					"type": "string"
+				},
+				"ua_icon": {
+					"type": "string"
+				},
+				"ua_name": {
+					"type": "string"
+				},
+				"ua_url": {
+					"type": "string"
+				},
+				"ua_version": {
+					"type": "string"
+				}
+			},
+			"additionalProperties": false
+		},
+		"user_agent": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false
+}

--- a/schemas/com.mandrill/message_clicked/jsonschema/1-0-1
+++ b/schemas/com.mandrill/message_clicked/jsonschema/1-0-1
@@ -5,7 +5,7 @@
 		"vendor": "com.mandrill",
 		"name": "message_clicked",
 		"format": "jsonschema",
-		"version": "1-0-0"
+		"version": "1-0-1"
 	},
 
 	"type": "object",

--- a/schemas/com.mandrill/message_delayed/jsonschema/1-0-1
+++ b/schemas/com.mandrill/message_delayed/jsonschema/1-0-1
@@ -1,0 +1,111 @@
+{
+	"$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+	"description": "Schema for a Mandrill message delayed event",
+	"self": {
+		"vendor": "com.mandrill",
+		"name": "message_delayed",
+		"format": "jsonschema",
+		"version": "1-0-0"
+	},
+
+	"type": "object",
+	"properties": {
+		"_id": {
+			"type": "string"
+		},
+		"msg": {
+			"type": "object",
+			"properties": {
+				"_id": {
+					"type": "string"
+				},
+				"_version": {
+					"type": "string"
+				},
+				"clicks": {
+					"type": "array"
+				},
+				"email": {
+					"type": "string"
+				},
+				"metadata": {
+					"type": "object",
+					"properties": {
+						"user_id": {
+							"type": "number"
+						}
+					},
+					"additionalProperties": true
+				},
+				"opens": {
+					"type": "array"
+				},
+				"sender": {
+					"type": "string"
+				},
+				"smtp_events": {
+					"type": "array",
+					"items": {
+						"type": "object",
+						"properties": {
+							"destination_ip": {
+								"type": "string"
+							},
+							"diag": {
+								"type": "string"
+							},
+							"size": {
+								"type": "number"
+							},
+							"source_ip": {
+								"type": "string"
+							},
+							"ts": {
+								"type": "string",
+								"format": "date-time"
+							},
+							"type": {
+								"type": "string"
+							}
+						},
+						"additionalProperties": true
+					}
+				},
+				"state": {
+					"type": "string"
+				},
+				"subaccount": {
+					"type": ["string", "null"]
+				},
+				"subject": {
+					"type": "string"
+				},
+				"tags": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"ts": {
+					"type": "string",
+					"format": "date-time"
+				},
+				"resends": {
+					"type": "array"
+				},
+				"template": {
+					"type": ["string", "null"]
+				}
+			},
+			"additionalProperties": false
+		},
+		"ts": {
+			"type": "string",
+			"format": "date-time"
+		},
+		"diag": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false
+}

--- a/schemas/com.mandrill/message_delayed/jsonschema/1-0-1
+++ b/schemas/com.mandrill/message_delayed/jsonschema/1-0-1
@@ -5,7 +5,7 @@
 		"vendor": "com.mandrill",
 		"name": "message_delayed",
 		"format": "jsonschema",
-		"version": "1-0-0"
+		"version": "1-0-1"
 	},
 
 	"type": "object",

--- a/schemas/com.mandrill/message_marked_as_spam/jsonschema/1-0-1
+++ b/schemas/com.mandrill/message_marked_as_spam/jsonschema/1-0-1
@@ -5,7 +5,7 @@
 		"vendor": "com.mandrill",
 		"name": "message_marked_as_spam",
 		"format": "jsonschema",
-		"version": "1-0-0"
+		"version": "1-0-1"
 	},
 
 	"type": "object",

--- a/schemas/com.mandrill/message_marked_as_spam/jsonschema/1-0-1
+++ b/schemas/com.mandrill/message_marked_as_spam/jsonschema/1-0-1
@@ -1,0 +1,97 @@
+{
+	"$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+	"description": "Schema for a Mandrill message marked as spam event",
+	"self": {
+		"vendor": "com.mandrill",
+		"name": "message_marked_as_spam",
+		"format": "jsonschema",
+		"version": "1-0-0"
+	},
+
+	"type": "object",
+	"properties": {
+		"_id": {
+			"type": "string"
+		},
+		"msg": {
+			"type": "object",
+			"properties": {
+				"_id": {
+					"type": "string"
+				},
+				"_version": {
+					"type": "string"
+				},
+				"clicks": {
+					"type": "array",
+					"items": {
+						"type": "object",
+						"properties": {
+							"ts": {
+								"type": "string",
+								"format": "date-time"
+							},
+							"url": {
+								"type": "string"
+							}
+						},
+						"additionalProperties": true
+					}
+				},
+				"email": {
+					"type": "string"
+				},
+				"metadata": {
+					"type": "object",
+					"properties": {
+						"user_id": {
+							"type": "number"
+						}
+					},
+					"additionalProperties": true
+				},
+				"opens": {
+					"type": "array",
+					"items": {
+						"type": "object",
+						"properties": {
+							"ts": {
+								"type": "string",
+								"format": "date-time"
+							}
+						},
+						"additionalProperties": true
+					}
+				},
+				"sender": {
+					"type": "string"
+				},
+				"state": {
+					"type": "string"
+				},
+				"subaccount": {
+					"type": ["string", "null"]
+				},
+				"subject": {
+					"type": "string"
+				},
+				"tags": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"ts": {
+					"type": "string",
+					"format": "date-time"
+				}
+			},
+			"additionalProperties": false
+		},
+		"ts": {
+			"type": "string",
+			"format": "date-time"
+		}
+	},
+	"additionalProperties": false
+}

--- a/schemas/com.mandrill/message_opened/jsonschema/1-0-1
+++ b/schemas/com.mandrill/message_opened/jsonschema/1-0-1
@@ -5,7 +5,7 @@
 		"vendor": "com.mandrill",
 		"name": "message_opened",
 		"format": "jsonschema",
-		"version": "1-0-0"
+		"version": "1-0-1"
 	},
 
 	"type": "object",

--- a/schemas/com.mandrill/message_opened/jsonschema/1-0-1
+++ b/schemas/com.mandrill/message_opened/jsonschema/1-0-1
@@ -1,0 +1,236 @@
+{
+	"$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+	"description": "Schema for a Mandrill message opened event",
+	"self": {
+		"vendor": "com.mandrill",
+		"name": "message_opened",
+		"format": "jsonschema",
+		"version": "1-0-0"
+	},
+
+	"type": "object",
+	"properties": {
+		"_id": {
+			"type": "string"
+		},
+		"ip": {
+			"type": "string"
+		},
+		"location": {
+			"type": "object",
+			"properties": {
+				"city": {
+					"type": "string"
+				},
+				"country_short": {
+					"type": "string"
+				},
+				"country": {
+					"type": "string"
+				},
+				"latitude": {
+					"type": "number"
+				},
+				"longitude": {
+					"type": "number"
+				},
+				"postal_code": {
+					"type": "string"
+				},
+				"region": {
+					"type": "string"
+				},
+				"timezone": {
+					"type": "string"
+				}
+			},
+			"additionalProperties": false
+		},
+		"msg": {
+			"type": "object",
+			"properties": {
+				"_id": {
+					"type": "string"
+				},
+				"_version": {
+					"type": "string"
+				},
+				"clicks": {
+					"type": "array",
+					"items": {
+						"type": "object",
+						"properties": {
+							"ts": {
+								"type": "string",
+								"format": "date-time"
+							},
+							"url": {
+								"type": "string"
+							},
+							"ip": {
+								"type": "string"
+							},
+							"location": {
+								"type": "string"
+							},
+							"ua": {
+								"type": "string"
+							}
+						},
+						"additionalProperties": true
+					}
+				},
+				"email": {
+					"type": "string"
+				},
+				"metadata": {
+					"type": "object",
+					"properties": {
+						"user_id": {
+							"type": "number"
+						}
+					},
+					"additionalProperties": true
+				},
+				"opens": {
+					"type": "array",
+					"items": {
+						"type": "object",
+						"properties": {
+							"ts": {
+								"type": "string",
+								"format": "date-time"
+							},
+							"ip": {
+								"type": "string"
+							},
+							"location": {
+								"type": ["string", "null"]
+							},
+							"ua": {
+								"type": "string"
+							}
+						},
+						"additionalProperties": true
+					}
+				},
+				"sender": {
+					"type": "string"
+				},
+				"state": {
+					"type": "string"
+				},
+				"subaccount": {
+					"type": ["string", "null"]
+				},
+				"subject": {
+					"type": "string"
+				},
+				"tags": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"ts": {
+					"type": "string",
+					"format": "date-time"
+				},
+				"resends": {
+					"type": "array"
+				},
+				"smtp_events": {
+					"type": "array",
+					"items": {
+						"type": "object",
+						"properties": {
+							"ts": {
+								"type": "string",
+								"format": "date-time"
+							},
+							"type": {
+								"type": "string"
+							},
+							"diag": {
+								"type": "string"
+							},
+							"source_ip": {
+								"type": "string"
+							},
+							"destination_ip": {
+								"type": "string"
+							},
+							"size": {
+								"type": "integer"
+							}					
+						},
+						"additionalProperties": true
+					}
+				},
+				"template": {
+					"type": ["string", "null"]
+				}
+			},
+			"additionalProperties": false
+		},
+		"ts": {
+			"type": "string",
+			"format": "date-time"
+		},
+		"user_agent_parsed": {
+			"type": "object",
+			"properties": {
+				"mobile": {
+					"type": "boolean"
+				},
+				"os_company_url": {
+					"type": ["string", "null"]
+				},
+				"os_company": {
+					"type": ["string", "null"]
+				},
+				"os_family": {
+					"type": ["string", "null"]
+				},
+				"os_icon": {
+					"type": ["string", "null"]
+				},
+				"os_name": {
+					"type": ["string", "null"]
+				},
+				"os_url": {
+					"type": ["string", "null"]
+				},
+				"type": {
+					"type": ["string", "null"]
+				},
+				"ua_company_url": {
+					"type": ["string", "null"]
+				},
+				"ua_company": {
+					"type": ["string", "null"]
+				},
+				"ua_family": {
+					"type": ["string", "null"]
+				},
+				"ua_icon": {
+					"type": ["string", "null"]
+				},
+				"ua_name": {
+					"type": ["string", "null"]
+				},
+				"ua_url": {
+					"type": ["string", "null"]
+				},
+				"ua_version": {
+					"type": ["string", "null"]
+				}
+			},
+			"additionalProperties": false
+		},
+		"user_agent": {
+			"type": "string"
+		}		
+	},
+	"additionalProperties": false
+}

--- a/schemas/com.mandrill/message_soft_bounced/jsonschema/1-0-1
+++ b/schemas/com.mandrill/message_soft_bounced/jsonschema/1-0-1
@@ -1,0 +1,111 @@
+{
+	"$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+	"description": "Schema for a Mandrill message soft bounced event",
+	"self": {
+		"vendor": "com.mandrill",
+		"name": "message_soft_bounced",
+		"format": "jsonschema",
+		"version": "1-0-0"
+	},
+
+	"type": "object",
+	"properties": {
+		"_id": {
+			"type": "string"
+		},
+		"msg": {
+			"type": "object",
+			"properties": {
+				"_id": {
+					"type": "string"
+				},
+				"_version": {
+					"type": "string"
+				},
+				"bgtools_code": {
+					"type": "number"
+				},
+				"bounce_description": {
+					"type": "string"
+				},
+				"diag": {
+					"type": "string"
+				},
+				"email": {
+					"type": "string"
+				},
+				"metadata": {
+					"type": "object",
+					"properties": {
+						"user_id": {
+							"type": "number"
+						}
+					},
+					"additionalProperties": true
+				},
+				"sender": {
+					"type": "string"
+				},
+				"state": {
+					"type": "string"
+				},
+				"subject": {
+					"type": "string"
+				},
+				"tags": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"ts": {
+					"type": "string",
+					"format": "date-time"
+				},
+				"resends": {
+					"type": "array"
+				},
+				"smtp_events": {
+					"type": "array",
+					"items": {
+						"type": "object",
+						"properties": {
+							"ts": {
+								"type": "string",
+								"format": "date-time"
+							},
+							"type": {
+								"type": "string"
+							},
+							"diag": {
+								"type": "string"
+							},
+							"source_ip": {
+								"type": "string"
+							},
+							"destination_ip": {
+								"type": "string"
+							},
+							"size": {
+								"type": "integer"
+							}					
+						},
+						"additionalProperties": true
+					}
+				},
+				"subaccount": {
+					"type": ["string", "null"]
+				},
+				"template": {
+					"type": ["string", "null"]
+				}
+			},
+			"additionalProperties": false
+		},
+		"ts": {
+			"type": "string",
+			"format": "date-time"
+		}
+	},
+	"additionalProperties": false
+}

--- a/schemas/com.mandrill/message_soft_bounced/jsonschema/1-0-1
+++ b/schemas/com.mandrill/message_soft_bounced/jsonschema/1-0-1
@@ -5,7 +5,7 @@
 		"vendor": "com.mandrill",
 		"name": "message_soft_bounced",
 		"format": "jsonschema",
-		"version": "1-0-0"
+		"version": "1-0-1"
 	},
 
 	"type": "object",

--- a/schemas/com.mandrill/recipient_unsubscribed/jsonschema/1-0-1
+++ b/schemas/com.mandrill/recipient_unsubscribed/jsonschema/1-0-1
@@ -5,7 +5,7 @@
 		"vendor": "com.mandrill",
 		"name": "recipient_unsubscribed",
 		"format": "jsonschema",
-		"version": "1-0-0"
+		"version": "1-0-1"
 	},
 
 	"type": "object",

--- a/schemas/com.mandrill/recipient_unsubscribed/jsonschema/1-0-1
+++ b/schemas/com.mandrill/recipient_unsubscribed/jsonschema/1-0-1
@@ -1,0 +1,97 @@
+{
+	"$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+	"description": "Schema for a Mandrill recipient unsubscribed event",
+	"self": {
+		"vendor": "com.mandrill",
+		"name": "recipient_unsubscribed",
+		"format": "jsonschema",
+		"version": "1-0-0"
+	},
+
+	"type": "object",
+	"properties": {
+		"_id": {
+			"type": "string"
+		},
+		"msg": {
+			"type": "object",
+			"properties": {
+				"_id": {
+					"type": "string"
+				},
+				"_version": {
+					"type": "string"
+				},
+				"clicks": {
+					"type": "array",
+					"items": {
+						"type": "object",
+						"properties": {
+							"ts": {
+								"type": "string",
+								"format": "date-time"
+							},
+							"url": {
+								"type": "string"
+							}
+						},
+						"additionalProperties": true
+					}
+				},
+				"email": {
+					"type": "string"
+				},
+				"metadata": {
+					"type": "object",
+					"properties": {
+						"user_id": {
+							"type": "number"
+						}
+					},
+					"additionalProperties": false
+				},
+				"opens": {
+					"type": "array",
+					"items": {
+						"type": "object",
+						"properties": {
+							"ts": {
+								"type": "string",
+								"format": "date-time"
+							}
+						},
+						"additionalProperties": true
+					}
+				},
+				"sender": {
+					"type": "string"
+				},
+				"state": {
+					"type": "string"
+				},
+				"subaccount": {
+					"type": ["string", "null"]
+				},
+				"subject": {
+					"type": "string"
+				},
+				"tags": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"ts": {
+					"type": "string",
+					"format": "date-time"
+				}
+			},
+			"additionalProperties": false
+		},
+		"ts": {
+			"type": "string",
+			"format": "date-time"
+		}
+	},
+	"additionalProperties": false
+}


### PR DESCRIPTION
The subaccount property is only currently included in the message_sent schema but appears in all Mandrill-sent events. This currently causes these events to fail enrichment.