### PR TITLE
Ssh tunnel

### DIFF
--- a/schemas/com.snowplowanalytics.snowplow.storage/postgresql_config/jsonschema/1-1-0
+++ b/schemas/com.snowplowanalytics.snowplow.storage/postgresql_config/jsonschema/1-1-0
@@ -1,0 +1,122 @@
+{
+    "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+    "description": "Snowplow PostgreSQL storage configuration",
+    "self": {
+        "vendor": "com.snowplowanalytics.snowplow.storage",
+        "name": "postgresql_config",
+        "format": "jsonschema",
+        "version": "1-1-0"
+    },
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string"
+        },
+        "host": {
+            "type": "string"
+        },
+        "database": {
+            "type": "string"
+        },
+        "port": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 65535
+        },
+        "sslMode": {
+            "type": "string",
+            "enum": ["DISABLE", "REQUIRE", "VERIFY_CA", "VERIFY_FULL"]
+        },
+        "schema": {
+            "type": "string"
+        },
+        "username": {
+            "type": "string"
+        },
+        "password": {
+            "type": ["string", "object"],
+            "properties": {
+                "ec2ParameterStore": {
+                    "type": "object",
+                    "properties": {
+                        "parameterName": {
+                            "type": "string"
+                        }
+                    },
+                    "required": ["parameterName"]
+                }
+            },
+            "required": ["ec2ParameterStore"]
+        },
+        "sshTunnel": {
+            "type": ["object", "null"],
+            "properties": {
+                "bastion": {
+                    "type": "object",
+                    "properties": {
+                        "host": {
+                            "type": "string"
+                        },
+                        "port": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 65535
+                        },
+                        "user": {
+                            "type": "string"
+                        },
+                        "passphrase": {
+                            "type": "string"
+                        },
+                        "key": {
+                            "type": "object",
+                            "properties": {
+                                "ec2ParameterStore": {
+                                    "type": "object",
+                                    "properties": {
+                                        "parameterName": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": ["parameterName"]
+                                }
+                            },
+                            "required": ["ec2ParameterStore"]
+                        }
+                    },
+                    "required": ["host", "port", "user"]
+                },
+                "destination": {
+                    "type": "object",
+                    "properties": {
+                        "host": {
+                            "type": "string"
+                        },
+                        "port": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 65535
+                        }
+                    },
+                    "required": ["host", "port"]
+                },
+                "localPort": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 65535
+                }
+            },
+            "required": ["bastion", "destination", "localPort"]
+        },
+        "id": {
+            "type": "string",
+            "format": "uuid"
+        },
+        "purpose": {
+            "type": "string",
+            "enum": ["ENRICHED_EVENTS"]
+        }
+    },
+    "additionalProperties": false,
+    "required": ["name", "host", "database", "port", "sslMode", "schema", "username", "password", "purpose"]
+}

--- a/schemas/com.snowplowanalytics.snowplow.storage/redshift_config/jsonschema/2-1-0
+++ b/schemas/com.snowplowanalytics.snowplow.storage/redshift_config/jsonschema/2-1-0
@@ -1,0 +1,136 @@
+{
+    "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+    "description": "Snowplow Redshift storage configuration",
+    "self": {
+        "vendor": "com.snowplowanalytics.snowplow.storage",
+        "name": "redshift_config",
+        "format": "jsonschema",
+        "version": "2-1-0"
+    },
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string"
+        },
+        "host": {
+            "type": "string"
+        },
+        "database": {
+            "type": "string"
+        },
+        "port": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 65535
+        },
+        "sslMode": {
+            "type": "string",
+            "enum": ["DISABLE", "REQUIRE", "VERIFY_CA", "VERIFY_FULL"]
+        },
+        "schema": {
+            "type": "string"
+        },
+        "username": {
+            "type": "string"
+        },
+        "password": {
+            "type": ["string", "object"],
+            "properties": {
+                "ec2ParameterStore": {
+                    "type": "object",
+                    "properties": {
+                        "parameterName": {
+                            "type": "string"
+                        }
+                    },
+                    "required": ["parameterName"]
+                }
+            },
+            "required": ["ec2ParameterStore"]
+        },
+        "maxError": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 10000
+        },
+        "compRows": {
+            "type": "integer",
+            "minimum": 1000,
+            "maximum": 1000000000
+        },
+        "roleArn": {
+            "type": "string",
+            "minLength": 20
+        },
+        "sshTunnel": {
+            "type": ["object", "null"],
+            "properties": {
+                "bastion": {
+                    "type": "object",
+                    "properties": {
+                        "host": {
+                            "type": "string"
+                        },
+                        "port": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 65535
+                        },
+                        "user": {
+                            "type": "string"
+                        },
+                        "passphrase": {
+                            "type": "string"
+                        },
+                        "key": {
+                            "type": "object",
+                            "properties": {
+                                "ec2ParameterStore": {
+                                    "type": "object",
+                                    "properties": {
+                                        "parameterName": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": ["parameterName"]
+                                }
+                            },
+                            "required": ["ec2ParameterStore"]
+                        }
+                    },
+                    "required": ["host", "port", "user"]
+                },
+                "destination": {
+                    "type": "object",
+                    "properties": {
+                        "host": {
+                            "type": "string"
+                        },
+                        "port": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 65535
+                        }
+                    },
+                    "required": ["host", "port"]
+                },
+                "localPort": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 65535
+                }
+            },
+            "required": ["bastion", "destination", "localPort"]
+        },
+        "id": {
+            "type": "string",
+            "format": "uuid"
+        },
+        "purpose": {
+            "type": "string",
+            "enum": ["ENRICHED_EVENTS"]
+        }
+    },
+    "additionalProperties": false,
+    "required": ["name", "host", "database", "port", "sslMode", "schema", "username", "password", "maxError", "compRows", "roleArn", "purpose"]
+}


### PR DESCRIPTION
Adds following property to PostgreSQL and Redshift:

```json
        "tunnel": {
            "type": ["object", "null"],
            "properties": {
                "host": {
                    "type": "string"
                },
                "port": {
                    "type": "integer",
                    "minimum": 1,
                    "maximum": 65535
                },
                "user": {
                    "type": "string"
                },
                "passphrase": {
                    "type": "string"
                },
                "sshKeyParameter": {
                    "type": "string"
                },
                "localPort": {
                    "type": "integer",
                    "minimum": 1,
                    "maximum": 65535
                },
                "destinationHost": {
                    "type": "string"
                },
                "destinationPort": {
                    "type": "integer",
                    "minimum": 1,
                    "maximum": 65535
                }
            },
            "required": ["host", "port", "user", "localPort", "destinationHost", "destinationPort"]
        }
```

Configuration will look like following:

```json
{
    "schema": "iglu:com.snowplowanalytics.snowplow.storage/redshift_config/jsonschema/2-0-0",
    "data": {
        "name": "AWS Redshift enriched events storage",
        "host": "localhost",
        "database": "snowplow",
        "port": 15151,
        "sslMode": "DISABLE",
        "username": "loader",
        "password": "Supersecret1",
        "roleArn": "arn:doesnmatter",
        "schema": "atomic",
        "maxError": 1,
        "compRows": 20000,
        "purpose": "ENRICHED_EVENTS",
        "tunnel": {
            "host": "bastion.acme.com",
            "port": 22,
            "user": "snowplow-loader",
            "localPort": 15151,
            "sshKeyParameter": "snowplow.rdbloader.redshift.key",
            "hostDestination": "10.0.0.11",
            "portDestination": 5439
        }
    }
}
```

@jbeemster proposed to omit `localPort` and choose arbitrary, but I think this would more explicit and also afraid EMR/Hadoop/etc might take this port eventually.