### PR TITLE
Patch com.snowplowanalytics.snowplow/mobile_context (closes #673)

### DIFF
--- a/schemas/com.snowplowanalytics.snowplow/mobile_context/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.snowplow/mobile_context/jsonschema/1-0-0
@@ -23,7 +23,7 @@
 			"type": "string"
 		},
 		"carrier": {
-			"type": "string"
+			"type": ["string", "null"]
 		},
 		"openIdfa": {
 			"type": "string"

--- a/schemas/com.snowplowanalytics.snowplow/mobile_context/jsonschema/1-0-1
+++ b/schemas/com.snowplowanalytics.snowplow/mobile_context/jsonschema/1-0-1
@@ -23,7 +23,7 @@
 			"type": "string"
 		},
 		"carrier": {
-			"type": "string"
+			"type": ["string", "null"]
 		},
 		"networkType": {
 			"enum": [ "mobile", "wifi", "offline" ]


### PR DESCRIPTION
We have come across a scenario when a device can produce no `carrier` resulting in `null` sent down the pipeline. Could we host an updated version of `mobile_context` with a relaxed restriction?

The changes required

```
"carrier": {
    "type": ["string", "null"]
}
```

No changes to SQL and jsonpaths.