### PR TITLE
Factotum Schema Patch

### DIFF
--- a/schemas/com.snowplowanalytics.factotum/job_update/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.factotum/job_update/jsonschema/1-0-0
@@ -114,12 +114,10 @@
 						"type": "string"
 					},
 					"stdout": {
-						"type": "string",
-						"maxLength": 10000
+						"type": "string"
 					},
 					"stderr": {
-						"type": "string",
-						"maxLength": 10000
+						"type": "string"
 					},
 					"returnCode": {
 						"type": "integer",

--- a/schemas/com.snowplowanalytics.factotum/task_update/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.factotum/task_update/jsonschema/1-0-0
@@ -124,12 +124,10 @@
 						"type": "string"
 					},
 					"stdout": {
-						"type": "string",
-						"maxLength": 10000
+						"type": "string"
 					},
 					"stderr": {
-						"type": "string",
-						"maxLength": 10000
+						"type": "string"
 					},
 					"returnCode": {
 						"type": "integer",


### PR DESCRIPTION
Hey @ninjabear @alexanderdean - so to use a higher string length in factotum we also need to patch these schemas.  I have opted for simply removing the limit on these fields as this gives us a lot more flexibility in terms of playing with much higher limits.  The SQL DLL also does not reference these fields directly as it is an array so nothing needs to be patched at that level.

Thoughts / qualms about this?