### PR TITLE
Add optional regexFile parameter for UaParserEnrichment configuration

### DIFF
--- a/schemas/com.snowplowanalytics.snowplow/ua_parser_config/jsonschema/1-0-1
+++ b/schemas/com.snowplowanalytics.snowplow/ua_parser_config/jsonschema/1-0-1
@@ -1,0 +1,35 @@
+{
+	"$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+	"description": "Schema for configuration of ua-parser enrichment",
+	"self": {
+		"vendor": "com.snowplowanalytics.snowplow",
+		"name": "ua_parser_config",
+		"format": "jsonschema",
+		"version": "1-0-1"
+	},
+
+	"type": "object",
+	"properties": {
+		"vendor": {
+			"type": "string"
+		},
+		"name": {
+			"type": "string"
+		},		
+		"enabled": {
+			"type": "boolean"
+		},
+		"parameters": {
+			"type": "object",
+			"properties": {
+				"regexFileUri": {
+					"type": "string"
+				}
+			},
+			"additionalProperties": false
+		}
+	},
+	"required": ["name", "vendor", "enabled"],
+	"additionalProperties": false
+}
+


### PR DESCRIPTION
This adds an optional `regexFile` parameter for the enrichment, as described in the changes made for snowplow/snowplow#3810.

It was unclear to me whether this should have bumped the version or not, since a browse of histories on others did not bump version on backwards compatible additions.