### PR TITLE
Add com.snowplowanalytics.snowplow.r2f/removal_criteria/jsonschema/1-0-0

### DIFF
--- a/schemas/com.snowplowanalytics.snowplow.r2f/removal_criteria/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.snowplow.r2f/removal_criteria/jsonschema/1-0-0
@@ -1,0 +1,98 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Schema for an individual entry in an R2F (Right to be forgotten) criteria file, each entry specifying an identifier for events that should be deleted.",
+  "self": {
+    "vendor": "com.snowplowanalytics.snowplow.r2f",
+    "name": "removal_criteria",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "type": "object",
+  "properties": {
+    "pojo": {
+      "description": "A scalar field from the EnrichedEvent POJO (e.g. user_id)",
+      "type": "object",
+      "properties": {
+        "fieldName": {
+          "enum": [
+            "user_id",
+            "user_ipaddress",
+            "user_fingerprint",
+            "domain_userid",
+            "network_userid",
+            "ip_organization",
+            "ip_domain",
+            "tr_orderid",
+            "ti_orderid",
+            "mkt_term",
+            "mkt_content",
+            "se_category",
+            "se_action",
+            "se_label",
+            "se_property",
+            "mkt_clickid",
+            "refr_domain_userid",
+            "domain_sessionid"
+          ],
+          "description": "The name of the field"
+        },
+        "valueForWhichEventWillBeDeleted": {
+          "type": "string",
+          "description": "The value that, if present in that field, will cause the event to be deleted"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "fieldName",
+        "valueForWhichEventWillBeDeleted"
+      ]
+    },
+    "json": {
+      "description": "A JSON field from the EnrichedEvent POJO (e.g. contexts).",
+      "type": "object",
+      "properties": {
+        "fieldName": {
+          "enum": [
+            "contexts",
+            "derived_contexts",
+            "unstruct_event"
+          ],
+          "description": "The name of the field"
+        },
+        "jsonPath": {
+          "type": "string",
+          "description": "The JsonPath that was specified"
+        },
+        "valueForWhichEventWillBeDeleted": {
+          "type": "string",
+          "description": "The value that, if present in that field, will cause the event to be deleted"
+        },
+        "schemaCriterion": {
+          "type": "string",
+          "description": "The iglu schema corresponding to this field and value",
+          "pattern": "^iglu:([a-zA-Z0-9-_.]+)/([a-zA-Z0-9-_]+)/([a-zA-Z0-9-_]+)/([1-9][0-9]*|\\*)-((?:0|[1-9][0-9]*)|\\*)-((?:0|[1-9][0-9]*)|\\*)$"
+        }
+      },
+      "required": [
+        "fieldName",
+        "jsonPath",
+        "valueForWhichEventWillBeDeleted",
+        "schemaCriterion"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "oneOf": [
+    {
+      "required": [
+        "pojo"
+      ]
+    },
+    {
+      "required": [
+        "json"
+      ]
+    }
+  ],
+  "additionalProperties": false
+}


### PR DESCRIPTION
Number of issues to resolve by the reviewers:

- [x] The list of acceptable pojo fields has simply been copied from PII, but do they all make sense for R2F or could they lead to removing data for multiple people?
- [x] Is r2f an acceptable name?
- [x] Is r2f in an acceptable namespace (com.snowplowanalytocs.snowplow)?