### PR TITLE
Clearbit: The southern hemisphere is not invalid

### DIFF
--- a/schemas/com.clearbit.enrichment/company/jsonschema/1-0-0
+++ b/schemas/com.clearbit.enrichment/company/jsonschema/1-0-0
@@ -59,8 +59,8 @@
         },
         "lng" : {
           "type" : ["number", "null"],
-          "minimum": -180,
-          "maximum": 180
+          "minimum" : -180,
+          "maximum" : 180
         },
         "state" : {
           "type" : ["string", "null"]
@@ -85,8 +85,8 @@
         },
         "lat" : {
           "type" : ["number", "null"],
-          "minimum": -90,
-          "maximum": 90
+          "minimum" : -90,
+          "maximum" : 90
         }
       },
       "additionalProperties" : true

--- a/schemas/com.clearbit.enrichment/company/jsonschema/1-0-0
+++ b/schemas/com.clearbit.enrichment/company/jsonschema/1-0-0
@@ -58,7 +58,9 @@
           "type" : ["string", "null"]
         },
         "lng" : {
-          "type" : ["number", "null"]
+          "type" : ["number", "null"],
+          "minimum": -180,
+          "maximum": 180
         },
         "state" : {
           "type" : ["string", "null"]
@@ -82,7 +84,9 @@
           "type" : ["string", "null"]
         },
         "lat" : {
-          "type" : ["number", "null"]
+          "type" : ["number", "null"],
+          "minimum": -90,
+          "maximum": 90
         }
       },
       "additionalProperties" : true

--- a/schemas/com.clearbit.enrichment/company/jsonschema/1-0-0
+++ b/schemas/com.clearbit.enrichment/company/jsonschema/1-0-0
@@ -82,8 +82,7 @@
           "type" : ["string", "null"]
         },
         "lat" : {
-          "type" : ["number", "null"],
-          "minimum" : 0
+          "type" : ["number", "null"]
         }
       },
       "additionalProperties" : true

--- a/schemas/com.clearbit.enrichment/person/jsonschema/1-0-0
+++ b/schemas/com.clearbit.enrichment/person/jsonschema/1-0-0
@@ -83,8 +83,8 @@
         },
         "lng" : {
           "type" : ["number", "null"],
-          "minimum": -180,
-          "maximum": 180
+          "minimum" : -180,
+          "maximum" : 180
         },
         "state" : {
           "type" : ["string", "null"]
@@ -98,7 +98,7 @@
         "lat" : {
           "type" : ["number", "null"],
           "minimum" : -90,
-          "maximum": 90
+          "maximum" : 90
         }
       },
       "additionalProperties" : true

--- a/schemas/com.clearbit.enrichment/person/jsonschema/1-0-0
+++ b/schemas/com.clearbit.enrichment/person/jsonschema/1-0-0
@@ -82,7 +82,9 @@
           "type" : ["string", "null"]
         },
         "lng" : {
-          "type" : ["number", "null"]
+          "type" : ["number", "null"],
+          "minimum": -180,
+          "maximum": 180
         },
         "state" : {
           "type" : ["string", "null"]
@@ -95,7 +97,8 @@
         },
         "lat" : {
           "type" : ["number", "null"],
-          "minimum" : 0
+          "minimum" : -90,
+          "maximum": 90
         }
       },
       "additionalProperties" : true


### PR DESCRIPTION
Setting a minimum for latitude invalidates payloads for Companies that have `geo` populated but are based in the Southern Hemisphere.
Not sure if the minimum was supposed to be for another field, but removing it for `lat` to fix this. 

Example payload:
```json
{
    "schema": "iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0",
    "data": {
        "schema": "iglu:com.clearbit.enrichment/company/jsonschema/1-0-0",
        "data": {
            "id": "e857288b-53dd-485e-a21b-f781fa947c34",
            "name": "Bolster",
            "legalName": null,
            "domain": "blstr.co",
            "domainAliases": ["bolsterdigital.com.au", "bolstermusic.com.au"],
            "url": "http://blstr.co",
            "site": {
                "url": "http://blstr.co",
                "title": "Built by Bolster. - Bolster.",
                "h1": "Bolster.",
                "metaDescription": "We create tailored digital strategy for music, events and entertainment clients who want to thrive online.",
                "metaAuthor": null,
                "phoneNumbers": [],
                "emailAddresses": ["hello@blstr.co", "info@blstr.co"]
            },
            "category": {
                "sector": "Information Technology",
                "industryGroup": "Software & Services",
                "industry": "Internet Software & Services",
                "subIndustry": "Internet Software & Services",
                "sicCode": "48",
                "naicsCode": "51"
            },
            "tags": ["B2C", "Technology", "Marketplace", "Internet"],
            "description": "We create tailored digital strategy for music, events and entertainment clients who want to thrive online.",
            "foundedYear": null,
            "location": "37 Islington St, Collingwood VIC 3066, Australia",
            "timeZone": "Australia/Melbourne",
            "utcOffset": 10,
            "geo": {
                "streetNumber": "37",
                "streetName": "Islington Street",
                "subPremise": null,
                "city": "Collingwood",
                "postalCode": "3066",
                "state": "Victoria",
                "stateCode": "VIC",
                "country": "Australia",
                "countryCode": "AU",
                "lat": -37.80818259999999,
                "lng": 144.9905375
            },
            "logo": "https://logo.clearbit.com/blstr.co",
            "facebook": {
                "handle": "blstr.co"
            },
            "linkedin": {
                "handle": "company/bolster-digital"
            },
            "twitter": {
                "handle": "bolsterco",
                "id": "4675224001",
                "bio": "Digital, Creative & Management Services for music, events & entertainment",
                "followers": 465,
                "following": 527,
                "location": "Collingwood, Melbourne",
                "site": "https://t.co/D1nTOqOfGb",
                "avatar": "https://pbs.twimg.com/profile_images/716850981502234624/bGKGUDyW_normal.jpg"
            },
            "crunchbase": {
                "handle": "organization/blastr"
            },
            "emailProvider": false,
            "type": "private",
            "ticker": null,
            "phone": null,
            "metrics": {
                "alexaUsRank": null,
                "alexaGlobalRank": 1229984,
                "employees": null,
                "employeesRange": null,
                "marketCap": null,
                "raised": null,
                "annualRevenue": null,
                "estimatedAnnualRevenue": null,
                "fiscalYearEnd": null
            },
            "tech": ["activecampaign", "google_tag_manager", "nginx", "wordpress", "segment", "facebook_advertiser", "piwik", "google_analytics", "hubspot"],
            "parent": {
                "domain": null
            }
        }
    }
}
```