### PR TITLE
Patch com.snowplowanalytics.monitoring.kinesis/storage_write_failed

### DIFF
--- a/schemas/com.snowplowanalytics.monitoring.kinesis/storage_write_failed/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.monitoring.kinesis/storage_write_failed/jsonschema/1-0-0
@@ -30,7 +30,7 @@
 			"minimum": 0
 		},
 		"message": {
-			"type": "string"
+			"type": ["string", "null"]
 		}
 	},
 


### PR DESCRIPTION
Hey @chuwy this seems to be the last "bad" event we have flowing through our internal pipeline so patching this would mean pretty much no data going to bad anymore!

Failures seem to be generated from the Elasticsearch Loader - I have opened a ticket there to explore why this appears to be sending null messages:

https://github.com/snowplow/snowplow-elasticsearch-loader/issues/124