### PR TITLE
Fix focus_form events being rejected by enrichment

### DIFF
--- a/schemas/com.snowplowanalytics.snowplow/focus_form/jsonschema/1-0-1
+++ b/schemas/com.snowplowanalytics.snowplow/focus_form/jsonschema/1-0-1
@@ -1,0 +1,47 @@
+{
+	"$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+	"description": "Schema for the focus of a form field",
+	"self": {
+		"vendor": "com.snowplowanalytics.snowplow",
+		"name": "focus_form",
+		"format": "jsonschema",
+		"version": "1-0-0"
+	},
+
+	"type": "object",
+	"properties": {
+		"formId": {
+			"type": "string",
+			"minLength": 0,
+			"maxLength": 64
+		},
+		"elementId": {
+			"type": "string",
+			"minLength": 0,
+			"maxLength": 64
+		},
+		"nodeName": {
+			"type": "string",
+			"enum": ["INPUT", "TEXTAREA", "SELECT"]
+		},
+		"type": {
+			"type": ["string", "null"],
+			"enum": ["button", "checkbox", "color", "date", "datetime", "datetime-local", "email", "file", "hidden", "image", "month", "number", "password", "radio", "range", "reset", "search", "submit", "tel", "text", "time", "url", "week"]
+		},
+		"elementClasses": {
+			"type": ["array", "null"],
+			"items": {
+				"type": "string",
+				"minLength": 0,
+				"maxLength": 64
+			}
+		},
+		"value": {
+			"type": ["string", "null"],
+			"minLength": 0,
+			"maxLength": 64
+		}
+	},
+	"required": ["formId", "elementId", "nodeName", "value"],
+	"additionalProperties": false
+}

--- a/schemas/com.snowplowanalytics.snowplow/focus_form/jsonschema/1-0-1
+++ b/schemas/com.snowplowanalytics.snowplow/focus_form/jsonschema/1-0-1
@@ -5,7 +5,7 @@
 		"vendor": "com.snowplowanalytics.snowplow",
 		"name": "focus_form",
 		"format": "jsonschema",
-		"version": "1-0-0"
+		"version": "1-0-1"
 	},
 
 	"type": "object",


### PR DESCRIPTION
# Background
I noticed a lot of the following errors in the Stream Enricher "bad" Kinesis Stream:
```
error: object instance has properties which are not allowed by the schema: ["type"]
    level: "error"
    schema: {"loadingURI":"#","pointer":""}
    instance: {"pointer":""}
    domain: "validation"
    keyword: "additionalProperties"
    unwanted: ["type"]
```
They happen mostly on `focus_form` events.
# Investigation
I took a look at [their schema](https://github.com/snowplow/iglu-central/blob/master/schemas/com.snowplowanalytics.snowplow/focus_form/jsonschema/1-0-0) and noticed they indeed do not accept an `type` property. However the schema does include an `elementType` property.
The [JavaScript Tracker](https://github.com/snowplow/snowplow-javascript-tracker/blob/master/core/lib/core.ts#L836) seems to send a `type` property for form events, but no `elementType`.
# Proposed solution
Therefore it seems to me that replacing the property in the schema would align with other form events and fix this problem.

Does that sound right?