### PR TITLE
Mailchimp profile updates will contain undocumented ip_signup param

### DIFF
--- a/schemas/com.mailchimp/profile_update/jsonschema/1-0-1
+++ b/schemas/com.mailchimp/profile_update/jsonschema/1-0-1
@@ -1,0 +1,67 @@
+{
+	"$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+	"description": "Schema for a Mailchimp profile update event",
+	"self": {
+		"vendor": "com.mailchimp",
+		"name": "profile_update",
+		"format": "jsonschema",
+		"version": "1-0-1"
+	},
+
+	"type": "object",
+	"properties": {
+		"data": {
+			"type": "object",
+			"properties": {
+				"email": {
+					"type": "string"
+				},
+				"email_type": {
+					"type": "string"
+				},
+				"id": {
+					"type": "string"
+				},
+				"web_id": {
+					"type": "string"
+				},
+				"ip_opt": {
+					"type": "string"
+				},
+				"ip_signup": {
+					"type": "string"
+				},
+				"list_id": {
+					"type": "string"
+				},
+				"merges": {
+					"type": "object",
+					"properties": {
+						"EMAIL": {
+							"type": ["string", "null"]
+						},
+						"FNAME": {
+							"type": ["string", "null"]
+						},
+						"LNAME": {
+							"type": ["string", "null"]
+						},
+						"INTERESTS": {
+							"type": ["string", "null"]
+						}
+					},
+					"additionalProperties": true
+				}
+			},
+			"additionalProperties": false
+		},
+		"fired_at": {
+			"type": "string",
+			"format": "date-time"
+		},
+		"type": {
+			"type": "string"
+		}
+	},
+	"additionalProperties": false
+}


### PR DESCRIPTION
Payload data for profile updates will include an undocumented ip_signup
param which will make the event enriching fail due to validation errors.