### PR TITLE
focus_form: use correct property name for type

### DIFF
--- a/schemas/com.snowplowanalytics.snowplow/focus_form/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.snowplow/focus_form/jsonschema/1-0-0
@@ -24,7 +24,7 @@
 			"type": "string",
 			"enum": ["INPUT", "TEXTAREA", "SELECT"]
 		},
-		"elementType": {
+		"type": {
 			"type": ["string", "null"],
 			"enum": ["button", "checkbox", "color", "date", "datetime", "datetime-local", "email", "file", "hidden", "image", "month", "number", "password", "radio", "range", "reset", "search", "submit", "tel", "text", "time", "url", "week"]
 		},


### PR DESCRIPTION
The JS tracker uses `type` to be consistent with the change_form and submit_form schemas: https://github.com/snowplow/snowplow-javascript-tracker/blob/ed751aaf8486f72d0abc0f0f880754c3dd61aa65/core/lib/core.ts#L859

Otherwise valid events using v1-0-0 of this focus_form schema will be going to bad because the schema is incorrect vs what's implemented in the tracker (due to `"additionalProperties": false`).

Not sure if this should be a new version or not given the circumstance? Is it possible someone would be using the `elementType` property somehow in prod, not with the JS tracker?