### PR TITLE
fix maxLength validation of country

### DIFF
--- a/schemas/com.mailgun/message_opened/jsonschema/1-0-0
+++ b/schemas/com.mailgun/message_opened/jsonschema/1-0-0
@@ -40,7 +40,7 @@
     "country": {
       "description": "Two-letter country code (as specified by ISO3166) the event came from or ‘unknown’ if it couldn’t be determined.",
       "type": "string",
-      "maxLength": 2
+      "maxLength": 8
     },
     "deviceType": {
       "description": "Device type the message was opened on. Can be ‘desktop’, ‘mobile’, ‘tablet’, ‘other’ or ‘unknown’.",


### PR DESCRIPTION
**Problem**:
Encountered maxLength validation error for `country` property. Original maxLength validation is 2 characters but the word unknown is allowed when country is not known and length for unknown word is 7.

This is the actual error that I get:
```
"message": "error: string "Unknown" is too long (length: 7, maximum allowed: 2)
    level: "error"
    schema: {"loadingURI":"#","pointer":"/properties/country"}
    instance: {"pointer":"/country"}
    domain: "validation"
    keyword: "maxLength"
    value: "Unknown"
    found: 7
    maxLength: 2
"
```

**Solution**:
Increase maxLength to 8 (to follow convention for region's maxLength as well)