### PR TITLE
client_session schema update to resolve type issue

### DIFF
--- a/schemas/com.snowplowanalytics.snowplow/client_session/jsonschema/1-0-1
+++ b/schemas/com.snowplowanalytics.snowplow/client_session/jsonschema/1-0-1
@@ -33,9 +33,7 @@
 			"enum": [ "SQLITE", "COOKIE_1", "COOKIE_3", "LOCAL_STORAGE", "FLASH_LSO" ]
 		},
 		"firstEventId": {
-			"type": [
-				"string"
-			],
+			"type": "string",
 			"format": "uuid"
 		}
 	},

--- a/schemas/com.snowplowanalytics.snowplow/client_session/jsonschema/1-0-1
+++ b/schemas/com.snowplowanalytics.snowplow/client_session/jsonschema/1-0-1
@@ -30,6 +30,7 @@
 			"format": "uuid"
 		},
 		"storageMechanism": {
+			"type": "string",
 			"enum": [ "SQLITE", "COOKIE_1", "COOKIE_3", "LOCAL_STORAGE", "FLASH_LSO" ]
 		},
 		"firstEventId": {


### PR DESCRIPTION
Extracts the single `type` string out of an array containing a single value.
This resolves issues with JSONSchema parsers fail when type arrays contain a single value:
> Union Type Schemas must contain two or more Simple Type Schemas