### PR TITLE
Patch com.snowplowanalytics.snowplow/mobile_context/jsonschema/1-0-1

### DIFF
--- a/schemas/com.snowplowanalytics.snowplow/mobile_context/jsonschema/1-0-1
+++ b/schemas/com.snowplowanalytics.snowplow/mobile_context/jsonschema/1-0-1
@@ -7,7 +7,6 @@
 		"format": "jsonschema",
 		"version": "1-0-1"
 	},
-
 	"type": "object",
 	"properties": {
 		"osType": {
@@ -26,6 +25,7 @@
 			"type": ["string", "null"]
 		},
 		"networkType": {
+			"type": "string",
 			"enum": [ "mobile", "wifi", "offline" ]
 		},
 		"networkTechnology": {


### PR DESCRIPTION
Specifies that the `networkType` `enum` `type` is a `string`. 
This should be a non-breaking change since it is only adding more specificity to the schema.
A type specification of enums is required for integrations such as [Fivetran](https://fivetran.com/docs/events/snowplow#schemainformation):
> If you want to store an enum value, add a type associated with it. All the enum values should be of same data type