### PR TITLE
Add recovery schemas

### DIFF
--- a/schemas/com.snowplowanalytics.snowplow.badrows/recovery_error/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.snowplow.badrows/recovery_error/jsonschema/1-0-0
@@ -1,0 +1,124 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Schema for errors reported by Snowplow Event Recovery",
+  "self": {
+    "vendor": "com.snowplowanalytics.snowplow.badrows",
+    "name": "recovery_error",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "type": "object",
+  "properties": {
+    "payload": {
+      "type": "object",
+      "properties": {
+        "schema": {
+          "type": "string",
+          "enum": [
+            "iglu:com.snowplowanalytics.snowplow.badrows/adapter_failures/jsonschema/1-0-0",
+            "iglu:com.snowplowanalytics.snowplow.badrows/collector_payload_format_violation/jsonschema/1-0-0",
+            "iglu:com.snowplowanalytics.snowplow.badrows/enrichment_failures/jsonschema/1-0-0",
+            "iglu:com.snowplowanalytics.snowplow.badrows/enrichment_failures/jsonschema/2-0-0",
+            "iglu:com.snowplowanalytics.snowplow.badrows/loader_iglu_error/jsonschema/2-0-0",
+            "iglu:com.snowplowanalytics.snowplow.badrows/loader_parsing_error/jsonschema/2-0-0",
+            "iglu:com.snowplowanalytics.snowplow.badrows/loader_recovery_error/jsonschema/1-0-0",
+            "iglu:com.snowplowanalytics.snowplow.badrows/loader_runtime_error/jsonschema/1-0-0",
+            "iglu:com.snowplowanalytics.snowplow.badrows/loader_runtime_error/jsonschema/1-0-1",
+            "iglu:com.snowplowanalytics.snowplow.badrows/relay_failure/jsonschema/1-0-0",
+            "iglu:com.snowplowanalytics.snowplow.badrows/schema_violations/jsonschema/1-0-0",
+            "iglu:com.snowplowanalytics.snowplow.badrows/schema_violations/jsonschema/2-0-0",
+            "iglu:com.snowplowanalytics.snowplow.badrows/size_violation/jsonschema/1-0-0",
+            "iglu:com.snowplowanalytics.snowplow.badrows/snowflake_error/jsonschema/1-0-0",
+            "iglu:com.snowplowanalytics.snowplow.badrows/tracker_protocol_violations/jsonschema/1-0-0"
+          ],
+          "description": "Original bad row schema"
+        },
+        "data": {
+          "type": "object",
+          "properties": {
+            "processor": {
+              "type": "object",
+              "description": "Original application that the bad row comes from"
+            },
+            "failure": {
+              "type": [
+                "object",
+                "array",
+                "string"
+              ],
+              "description": "Original failure reason(s)"
+            },
+            "payload": {
+              "type": [
+                "object",
+                "string"
+              ],
+              "description": "Original payload object, can be a full payload object or a raw payload string"
+            }
+          },
+          "required": [
+            "processor",
+            "failure"
+          ],
+          "description": "Original bad row contents"
+        }
+      },
+      "required": [
+        "schema",
+        "data"
+      ],
+      "description": "Original bad row"
+    },
+    "recoveries": {
+      "type": "integer",
+      "description": "Number of times payload recovery has been tried"
+    },
+    "failure": {
+      "description": "A reason why payload could not be recovered",
+      "properties": {
+        "error": {
+          "description": "Human-readable error",
+          "type": "string"
+        },
+        "configName": {
+          "description": "Name of recovery configuration that failed",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "error"
+      ]
+    },
+    "processor": {
+      "type": "object",
+      "description": "Information about the piece of software responsible for the creation of enrichment failures",
+      "properties": {
+        "artifact": {
+          "type": "string",
+          "description": "Artifact responsible for the creation of enrichment failures",
+          "maxLength": 512
+        },
+        "version": {
+          "type": "string",
+          "description": "Version of the artifact responsible for the creation of enrichment failures",
+          "pattern": "^(\\d+\\.\\d+\\.\\d+.*)$",
+          "maxLength": 32
+        }
+      },
+      "required": [
+        "artifact",
+        "version"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "payload",
+    "failure",
+    "processor"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/com.snowplowanalytics.snowplow/recoveries/jsonschema/2-0-0
+++ b/schemas/com.snowplowanalytics.snowplow/recoveries/jsonschema/2-0-0
@@ -1,0 +1,255 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Schema for an array of recovery scenarios",
+  "self": {
+    "vendor": "com.snowplowanalytics.snowplow",
+    "name": "recoveries",
+    "format": "jsonschema",
+    "version": "2-0-0"
+  },
+  "type": "object",
+  "minProperties": 1,
+  "patternProperties": {
+    "^iglu:": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "pattern": "^(([a-zA-Z0-9]+)(-?))+$",
+            "minLength": 1,
+            "description": "A slug name for recovery flow"
+          },
+          "conditions": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "op": {
+                  "type": "string",
+                  "enum": [
+                    "Cast",
+                    "Remove",
+                    "Replace",
+                    "Test"
+                  ],
+                  "description": "Transformation operation to perform"
+                },
+                "path": {
+                  "type": "string",
+                  "pattern": "^(([a-zA-Z0-9]+)(\\.?))+$",
+                  "description": "JSON Path to object"
+                },
+                "match": {
+                  "type": "string",
+                  "description": "An expression applied when replacing field’s values with new value"
+                },
+                "value": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object",
+                      "description": "Compare against static value",
+                      "properties": {
+                        "value": {
+                          "type": [
+                            "array",
+                            "number",
+                            "object",
+                            "string"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "description": "Compare against regular expression",
+                      "properties": {
+                        "regex": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "regex"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "description": "Compare size",
+                      "properties": {
+                        "size": {
+                          "type": "object",
+                          "oneOf": [
+                            {
+                              "properties": {
+                                "eq": {
+                                  "type": "integer"
+                                }
+                              }
+                            },
+                            {
+                              "properties": {
+                                "lt": {
+                                  "type": "integer"
+                                }
+                              }
+                            },
+                            {
+                              "properties": {
+                                "gt": {
+                                  "type": "integer"
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  ],
+                  "description": "A value to match against"
+                },
+                "from": {
+                  "type": "string",
+                  "description": "Source type to cast from"
+                },
+                "to": {
+                  "type": "string",
+                  "description": "Target type to cast to"
+                }
+              },
+              "required": [
+                "op",
+                "path",
+                "value"
+              ],
+              "additionalProperties": false
+            },
+            "description": "Conditions required to apply steps for specific Bad Row type"
+          },
+          "steps": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "op": {
+                  "type": "string",
+                  "enum": [
+                    "Cast",
+                    "Remove",
+                    "Replace",
+                    "Test"
+                  ],
+                  "description": "Transformation operation to perform"
+                },
+                "path": {
+                  "type": "string",
+                  "pattern": "^(([a-zA-Z0-9]+)(\\.?))+$",
+                  "description": "JSON Path to object"
+                },
+                "match": {
+                  "type": "string",
+                  "description": "An expression applied when replacing field’s values with new value"
+                },
+                "value": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object",
+                      "description": "Compare against static value",
+                      "properties": {
+                        "value": {
+                          "type": [
+                            "number",
+                            "object",
+                            "string"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "description": "Compare against regular expression",
+                      "properties": {
+                        "regex": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "regex"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "description": "Compare size",
+                      "properties": {
+                        "size": {
+                          "type": "object",
+                          "oneOf": [
+                            {
+                              "properties": {
+                                "eq": {
+                                  "type": "integer"
+                                }
+                              }
+                            },
+                            {
+                              "properties": {
+                                "lt": {
+                                  "type": "integer"
+                                }
+                              }
+                            },
+                            {
+                              "properties": {
+                                "gt": {
+                                  "type": "integer"
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  ],
+                  "description": "A value to match against"
+                },
+                "from": {
+                  "type": "string",
+                  "description": "Source type to cast from"
+                },
+                "to": {
+                  "type": "string",
+                  "description": "Target type to cast to"
+                }
+              },
+              "required": [
+                "op",
+                "path",
+                "value"
+              ],
+              "additionalProperties": false
+            },
+            "description": "Steps to be applied for specific Bad Row type"
+          }
+        },
+        "required": [
+          "name",
+          "conditions",
+          "steps"
+        ],
+        "additionalProperties": {
+          "type": "array"
+        }
+      }
+    }
+  }
+}

--- a/schemas/com.snowplowanalytics.snowplow/recoveries/jsonschema/2-0-0
+++ b/schemas/com.snowplowanalytics.snowplow/recoveries/jsonschema/2-0-0
@@ -245,10 +245,7 @@
           "name",
           "conditions",
           "steps"
-        ],
-        "additionalProperties": {
-          "type": "array"
-        }
+        ]
       }
     }
   }


### PR DESCRIPTION
Adds new/updated schemas for [recovery 0.2+](https://github.com/snowplow-incubator/snowplow-event-recovery/pull/43) with support for the new bad row format:
- configuration
- additional bad row format for failed recoveries and unrecoverable bad rows