### PR TITLE
Add org.ietf/http_client_hints/jsonschema/1-0-0 (closes #1061)

### DIFF
--- a/schemas/org.ietf/http_client_hints/jsonschema/1-0-0
+++ b/schemas/org.ietf/http_client_hints/jsonschema/1-0-0
@@ -1,0 +1,55 @@
+{
+  "$schema" : "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "self" : {
+    "vendor" : "org.ietf",
+    "name" : "http_client_hints",
+    "version" : "1-0-0",
+    "format" : "jsonschema"
+  },
+  "type" : "object",
+  "properties" : {
+    "isMobile" : {
+      "type" : "boolean"
+    },
+    "brands" : {
+      "type" : "array",
+      "items" : {
+        "type" : "object",
+        "properties" : {
+          "brand" : {
+            "type" : "string",
+            "maxLength" : 4096
+          },
+          "version" : {
+            "type" : "string",
+            "maxLength" : 128
+          }
+        },
+        "required": ["brand", "version"],
+        "additionalProperties" : false
+      }
+    },
+    "architecture" : {
+      "type": ["string", "null"],
+      "maxLength" : 4096
+    },
+    "model" : {
+      "type": ["string", "null"],
+      "maxLength" : 4096
+    },
+    "platform" : {
+      "type": ["string", "null"],
+      "maxLength" : 4096
+    },
+    "platformVersion" : {
+      "type": ["string", "null"],
+      "maxLength" : 4096
+    },
+    "uaFullVersion" : {
+      "type": ["string", "null"],
+      "maxLength" : 4096
+    }
+  },
+  "required": ["isMobile", "brands"],
+  "additionalProperties" : false
+}


### PR DESCRIPTION
Required before 2.15.0 of the JavaScript can be released. 

The `isMobile` and `brands` properties will always be populated. The other 5 properties are deemed "High Entropy" and will be optionally requested, therefore they might not be present when sending this context.

I appreciate that `brands` is a little complex to deal with but the browser is allowed to respond with mulitple brands. For example, Chrome currently responses with Chrome, v84 and Chromium, v84 as two separate entities. It's expected Edge will also adopt this feature soon and will respond with Edge, v84 and Chromium, v84. There is no guarenteed order to these so there is little I can do to select a single one and it seems the best action is to capture them all and attempt to deal with them downstream.