### PR TITLE
Patch com.snowplowanalytics.snowplow missing enum types

### DIFF
--- a/schemas/com.snowplowanalytics.snowplow/application_error/jsonschema/1-0-2
+++ b/schemas/com.snowplowanalytics.snowplow/application_error/jsonschema/1-0-2
@@ -11,6 +11,7 @@
   "type": "object",
   "properties": {
     "programmingLanguage": {
+      "type": "string",
       "enum": [
         "JAVA",
         "SCALA",

--- a/schemas/com.snowplowanalytics.snowplow/campaign_attribution/jsonschema/1-0-1
+++ b/schemas/com.snowplowanalytics.snowplow/campaign_attribution/jsonschema/1-0-1
@@ -23,6 +23,7 @@
 			"type": "object",
 			"properties": {
 				"mapping": {
+					"type": ["string", "null"],
 					"enum": ["static", "script"]
 				},
 				"fields": {

--- a/schemas/com.snowplowanalytics.snowplow/gdpr/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.snowplow/gdpr/jsonschema/1-0-0
@@ -11,6 +11,7 @@
     "type": "object",
     "properties": {
         "basisForProcessing": {
+          "type": "string",
           "enum": ["consent", "contract", "legal_obligation", "vital_interests", "public_task", "legitimate_interests"],
           "description": "GDPR basis for data collection & processing"
         },


### PR DESCRIPTION
Adds missing `type` fields in enum properties. 
This resolves issues similar to those described in #1030, #1031, #1032, #1033, #1038

cc @paulboocock 