### PR TITLE
db-ip.com schemas

### DIFF
--- a/schemas/com.dbip/isp/jsonschema/1-0-0
+++ b/schemas/com.dbip/isp/jsonschema/1-0-0
@@ -1,0 +1,200 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Schema for db-ip.com location isp dataset",
+  "self": {
+          "vendor": "com.dbip",
+          "name": "isp",
+          "format": "jsonschema",
+          "version": "1-0-0"
+  },
+  "type": "object",
+  "properties": {
+    "continent": {
+        "description": "The continent object",
+        "type": ["object","null"],        
+        "properties": {
+            "code": {
+                "type": ["string","null"],
+                "description": "The continent code e.g. EU",
+                "maxLength": 255
+            },        
+            "geoname_id": {
+                "description": "The continent geoname id",
+                "type": ["number","null"],
+                "minimum": 0,              
+                "maximum": 9223372036854775807
+            },
+            "names": {
+                "description": "The continent names",
+                "type": ["object","null"],        
+                    "properties": {        
+                            "en": {
+                                "type": ["string","null"],
+                                "description": "Continent name in english e.g. Europe",
+                                "maxLength": 255
+                            },
+                            "de": {
+                                "type": ["string","null"],
+                                "description": "Continent name in german",
+                                "maxLength": 255
+                            },
+                            "es": {
+                                "type": ["string","null"],
+                                "description": "Continent name in spanish",
+                                "maxLength": 255
+                            },
+                            "fa": {
+                                "type": ["string","null"],
+                                "description": "Continent name in farsi",
+                                "maxLength": 255
+                            },
+                            "fr": {
+                                "type": ["string","null"],
+                                "description": "Continent name in french",
+                                "maxLength": 255
+                            },
+                            "ja": {
+                                "type": ["string","null"],
+                                "description": "Continent name in japanese",
+                                "maxLength": 255
+                            },
+                            "ko": {
+                                "type": ["string","null"],
+                                "description": "Continent name in korean",
+                                "maxLength": 255
+                            },
+                            "pt-BR": {
+                                "type": ["string","null"],
+                                "description": "Continent name in portuguese",
+                                "maxLength": 255
+                            },
+                            "ru": {
+                                "type": ["string","null"],
+                                "description": "Continent name in russian",
+                                "maxLength": 255
+                            }
+                    }
+            }
+        }
+    },
+
+    "country": {
+        "description": "The country object",
+        "type": ["object","null"],        
+        "properties": {
+            "iso_code": {
+                "type": ["string","null"],
+                "description": "The country ISO code e.g. PT",
+                "maxLength": 255
+            },    
+            "is_in_european_union": {
+                "type": ["boolean","null"],
+                "description": "True if country is in European Union"
+            },              
+            "geoname_id": {
+                "description": "The country geoname id",
+                "type": ["number","null"],
+                "minimum": 0,              
+                "maximum": 2147483647
+            },
+            "names": {
+                "description": "The country names",
+                "type": ["object","null"],        
+                    "properties": {        
+                            "en": {
+                                "type": ["string","null"],
+                                "description": "Country name in english e.g. Portugal",
+                                "maxLength": 255
+                            },
+                            "de": {
+                                "type": ["string","null"],
+                                "description": "Country name in german",
+                                "maxLength": 255
+                            },
+                            "es": {
+                                "type": ["string","null"],
+                                "description": "Country name in spanish",
+                                "maxLength": 255
+                            },
+                            "fa": {
+                                "type": ["string","null"],
+                                "description": "Country name in farsi",
+                                "maxLength": 255
+                            },
+                            "fr": {
+                                "type": ["string","null"],
+                                "description": "Country name in french",
+                                "maxLength": 255
+                            },
+                            "ja": {
+                                "type": ["string","null"],
+                                "description": "Country name in japanese",
+                                "maxLength": 255
+                            },
+                            "ko": {
+                                "type": ["string","null"],
+                                "description": "Country name in korean",
+                                "maxLength": 255
+                            },
+                            "pt-BR": {
+                                "type": ["string","null"],
+                                "description": "Country name in portuguese",
+                                "maxLength": 255
+                            },
+                            "ru": {
+                                "type": ["string","null"],
+                                "description": "Country name in russian",
+                                "maxLength": 255
+                            }
+                    }
+            }
+        }
+    },
+
+    "traits": {
+        "description": "Traits",
+        "type": ["object","null"],        
+            "properties": {        
+                    "autonomous_system_number": {
+                        "type": ["number","null"],
+                        "description": "The autonomous system number",
+                        "minimum": 0,
+                        "maximum": 2147483647
+                    },
+                    "autonomous_system_organization": {
+                        "type": ["string","null"],
+                        "description": "AS organization name",
+                        "maxLength": 255
+                    },
+                    "connection_type": {
+                        "type": ["string","null"],
+                        "description": "Connection type e.g. Dialup,Cable/DSL,Cellular,Corporate",
+                        "maxLength": 255
+                    },
+                    "isp": {
+                        "type": ["string","null"],
+                        "description": "Internet Service Provider name",
+                        "maxLength": 255
+                    },
+                    "organization": {
+                        "type": ["string","null"],
+                        "description": "City name in french",
+                        "maxLength": 255
+                    },
+                    "ja": {
+                        "type": ["string","null"],
+                        "description": "City name in japanese",
+                        "maxLength": 255
+                    },
+                    "ko": {
+                        "type": ["string","null"],
+                        "description": "Organization name",
+                        "maxLength": 255
+                    }
+            }
+    }
+    
+  },
+  "minProperties": 1,
+  "additionalProperties": true
+}

--- a/schemas/com.dbip/location/jsonschema/1-0-0
+++ b/schemas/com.dbip/location/jsonschema/1-0-0
@@ -1,0 +1,338 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Schema for db-ip.com location dataset",
+  "self": {
+          "vendor": "com.dbip",
+          "name": "location",
+          "format": "jsonschema",
+          "version": "1-0-0"
+  },
+  "type": "object",
+  "properties": {
+
+    "continent": {
+    "description": "The continent object",
+    "type": ["object","null"],        
+        "properties": {
+            "code": {
+                "type": ["string","null"],
+                "description": "The continent code e.g. EU",
+                "maxLength": 255
+            },        
+            "geoname_id": {
+                "description": "The continent geoname id",
+                "type": ["number","null"],
+                "minimum": 0,              
+                "maximum": 9223372036854775807
+            },
+            "names": {
+                "description": "The continent names",
+                "type": ["object","null"],        
+                    "properties": {        
+                            "en": {
+                                "type": ["string","null"],
+                                "description": "Continent name in english e.g. Europe",
+                                "maxLength": 255
+                            },
+                            "de": {
+                                "type": ["string","null"],
+                                "description": "Continent name in german",
+                                "maxLength": 255
+                            },
+                            "es": {
+                                "type": ["string","null"],
+                                "description": "Continent name in spanish",
+                                "maxLength": 255
+                            },
+                            "fa": {
+                                "type": ["string","null"],
+                                "description": "Continent name in farsi",
+                                "maxLength": 255
+                            },
+                            "fr": {
+                                "type": ["string","null"],
+                                "description": "Continent name in french",
+                                "maxLength": 255
+                            },
+                            "ja": {
+                                "type": ["string","null"],
+                                "description": "Continent name in japanese",
+                                "maxLength": 255
+                            },
+                            "ko": {
+                                "type": ["string","null"],
+                                "description": "Continent name in korean",
+                                "maxLength": 255
+                            },
+                            "pt-BR": {
+                                "type": ["string","null"],
+                                "description": "Continent name in portuguese",
+                                "maxLength": 255
+                            },
+                            "ru": {
+                                "type": ["string","null"],
+                                "description": "Continent name in russian",
+                                "maxLength": 255
+                            }
+                    }
+            }
+        }
+    },
+
+    "country": {
+    "description": "The country object",
+    "type": ["object","null"],        
+        "properties": {
+            "iso_code": {
+                "type": ["string","null"],
+                "description": "The country ISO code e.g. PT",
+                "maxLength": 255
+            },    
+            "is_in_european_union": {
+                "type": ["boolean","null"],
+                "description": "True if country is in European Union"
+            },              
+            "geoname_id": {
+                "description": "The country geoname id",
+                "type": ["number","null"],
+                "minimum": 0,              
+                "maximum": 2147483647
+            },
+            "names": {
+                "description": "The country names",
+                "type": ["object","null"],        
+                    "properties": {        
+                            "en": {
+                                "type": ["string","null"],
+                                "description": "Country name in english e.g. Portugal",
+                                "maxLength": 255
+                            },
+                            "de": {
+                                "type": ["string","null"],
+                                "description": "Country name in german",
+                                "maxLength": 255
+                            },
+                            "es": {
+                                "type": ["string","null"],
+                                "description": "Country name in spanish",
+                                "maxLength": 255
+                            },
+                            "fa": {
+                                "type": ["string","null"],
+                                "description": "Country name in farsi",
+                                "maxLength": 255
+                            },
+                            "fr": {
+                                "type": ["string","null"],
+                                "description": "Country name in french",
+                                "maxLength": 255
+                            },
+                            "ja": {
+                                "type": ["string","null"],
+                                "description": "Country name in japanese",
+                                "maxLength": 255
+                            },
+                            "ko": {
+                                "type": ["string","null"],
+                                "description": "Country name in korean",
+                                "maxLength": 255
+                            },
+                            "pt-BR": {
+                                "type": ["string","null"],
+                                "description": "Country name in portuguese",
+                                "maxLength": 255
+                            },
+                            "ru": {
+                                "type": ["string","null"],
+                                "description": "Country name in russian",
+                                "maxLength": 255
+                            }
+                    }
+            }
+        }
+    },
+
+    "city": {
+        "description": "The city object",
+        "type": ["object","null"],        
+            "properties": {
+                "geoname_id": {
+                    "description": "The city geoname id",
+                    "type": ["number","null"],
+                    "minimum": 0,              
+                    "maximum": 9223372036854775807
+                },
+                "names": {
+                    "description": "The city names",
+                    "type": ["object","null"],        
+                        "properties": {        
+                                "en": {
+                                    "type": ["string","null"],
+                                    "description": "City name in english",
+                                    "maxLength": 255
+                                },
+                                "de": {
+                                    "type": ["string","null"],
+                                    "description": "City name in german",
+                                    "maxLength": 255
+                                },
+                                "es": {
+                                    "type": ["string","null"],
+                                    "description": "City name in spanish",
+                                    "maxLength": 255
+                                },
+                                "fa": {
+                                    "type": ["string","null"],
+                                    "description": "City name in farsi",
+                                    "maxLength": 255
+                                },
+                                "fr": {
+                                    "type": ["string","null"],
+                                    "description": "City name in french",
+                                    "maxLength": 255
+                                },
+                                "ja": {
+                                    "type": ["string","null"],
+                                    "description": "City name in japanese",
+                                    "maxLength": 255
+                                },
+                                "ko": {
+                                    "type": ["string","null"],
+                                    "description": "City name in korean",
+                                    "maxLength": 255
+                                },
+                                "pt-BR": {
+                                    "type": ["string","null"],
+                                    "description": "City name in portuguese",
+                                    "maxLength": 255
+                                },
+                                "ru": {
+                                    "type": ["string","null"],
+                                    "description": "City name in russian",
+                                    "maxLength": 255
+                                }
+                        }
+                }
+            }
+    },
+
+    "location": {
+    "description": "The location object",
+    "type": ["object","null"],        
+        "properties": {
+            "time_zone": {
+                "type": ["string","null"],
+                "description": "The timezone e.g Europe/Lisbon",
+                "maxLength": 255
+            },  
+            "weather_code": {
+                "type": ["string","null"],
+                "description": "The nearest weather code e.g. POXX0016",
+                "maxLength": 255
+            },                
+            "latitude": {
+                "type": ["number","null"],
+                "description": "The latitude",
+                "minimum": -2147483647,              
+                "maximum": 2147483647            
+            },
+            "longitude": {
+                "type": ["number","null"],
+                "description": "The longitude",
+                "minimum": -2147483647,              
+                "maximum": 2147483647   
+                }
+        }        
+    },
+  
+    "postal": {
+        "description": "The postal object",
+        "type": ["object","null"],        
+            "properties": {
+                "code": {
+                    "type": ["string","null"],
+                    "description": "The postal code e.g 92037",
+                    "maxLength": 255
+                }
+            }      
+    },
+
+    "subdivisions": {
+        "description": "Subdivisions",
+        "type": ["array","null"],
+        "minItems": 0,
+        "items": {
+            "description": "Geo subdivisions",
+            "type": ["object","null"],        
+                "properties": {
+                    "geoname_id": {
+                        "description": "Geoname id",
+                        "type": ["number","null"],
+                        "minimum": 0,              
+                        "maximum": 2147483647
+                    },
+                    "iso_code": {
+                        "type": ["string","null"],
+                        "description": "The ISO code for the geo name",
+                        "maxLength": 255
+                    }, 
+                    "names": {
+                        "description": "The subdivision names",
+                        "type": ["object","null"],        
+                            "properties": {        
+                                    "en": {
+                                        "type": ["string","null"],
+                                        "description": "Subdivision name in english",
+                                        "maxLength": 255
+                                    },
+                                    "de": {
+                                        "type": ["string","null"],
+                                        "description": "Subdivision name in german",
+                                        "maxLength": 255
+                                    },
+                                    "es": {
+                                        "type": ["string","null"],
+                                        "description": "Subdivision name in spanish",
+                                        "maxLength": 255
+                                    },
+                                    "fa": {
+                                        "type": ["string","null"],
+                                        "description": "Subdivision name in farsi",
+                                        "maxLength": 255
+                                    },
+                                    "fr": {
+                                        "type": ["string","null"],
+                                        "description": "Subdivision name in french",
+                                        "maxLength": 255
+                                    },
+                                    "ja": {
+                                        "type": ["string","null"],
+                                        "description": "Subdivision name in japanese",
+                                        "maxLength": 255
+                                    },
+                                    "ko": {
+                                        "type": ["string","null"],
+                                        "description": "Subdivision name in korean",
+                                        "maxLength": 255
+                                    },
+                                    "pt-BR": {
+                                        "type": ["string","null"],
+                                        "description": "Subdivision name in portuguese",
+                                        "maxLength": 255
+                                    },
+                                    "ru": {
+                                        "type": ["string","null"],
+                                        "description": "Subdivision name in russian",
+                                        "maxLength": 255
+                                    }
+                            }
+                    }
+                }
+        } 
+    }
+
+    },
+
+  "minProperties": 1,
+  "additionalProperties": true
+}


### PR DESCRIPTION
Added schemas location and ISP for db-ip.com. 

I've tested these schemas extensively, on Mini, Micro, and production latest scala collector and enricher. 
Ideally, you should set this as a Snowplow enrichment. 

See example payload below:

`    "contexts_com_dbip_location_1": [
      {
        "city": {
          "geoname_id": 5342353,
          "names": {
            "en": "Del Mar",
            "fa": "دل مار، کالیفرنیا",
            "ja": "デル・マー",
            "zh-CN": "德尔马"
          }
        },
        "continent": {
          "code": "NA",
          "geoname_id": 6255149,
          "names": {
            "de": "Nordamerika",
            "en": "North America",
            "es": "Norteamérica",
            "fa": " امریکای شمالی",
            "fr": "Amérique Du Nord",
            "ja": "北アメリカ大陸",
            "ko": "북아메리카",
            "pt-BR": "América Do Norte",
            "ru": "Северная Америка",
            "zh-CN": "北美洲"
          }
        },
        "country": {
          "geoname_id": 6252001,
          "is_in_european_union": false,
          "iso_code": "US",
          "names": {
            "de": "Vereinigte Staaten von Amerika",
            "en": "United States",
            "es": "Estados Unidos de América (los)",
            "fa": "ایالات متحدهٔ امریکا",
            "fr": "États-Unis",
            "ja": "アメリカ合衆国",
            "ko": "미국",
            "pt-BR": "Estados Unidos",
            "ru": "США",
            "zh-CN": "美国"
          }
        },
        "location": {
          "latitude": 32.9595,
          "longitude": -117.265,
          "time_zone": "America/Los_Angeles",
          "weather_code": "USCA0288"
        },
        "postal": {
          "code": "92014"
        },
        "subdivisions": [
          {
            "geoname_id": 5332921,
            "iso_code": "CA",
            "names": {
              "de": "Kalifornien",
              "en": "California",
              "es": "California",
              "fa": "کالیفرنیا",
              "fr": "Californie",
              "ja": "カリフォルニア州",
              "ko": "캘리포니아 주",
              "pt-BR": "Califórnia",
              "ru": "Калифорния",
              "zh-CN": "加利福尼亚州"
            }
          },
          {
            "geoname_id": 5391832,
            "names": {
              "en": "San Diego",
              "es": "Condado de San Diego",
              "fa": "شهرستان سن دیگو، کالیفرنیا",
              "fr": "Comté de San Diego",
              "ja": "サンディエゴ郡",
              "ko": "샌디에이고 군",
              "pt-BR": "Condado de San Diego",
              "ru": "Сан-Диего",
              "zh-CN": "圣迭戈县"
            }
          }
        ]
      }
    ]`

and ISP

`    "contexts_com_dbip_isp_1": [
      {
        "traits": {
          "autonomous_system_number": 20001,
          "autonomous_system_organization": "Charter Communications Inc",
          "connection_type": "Corporate",
          "isp": "Charter Communications",
          "organization": "Spectrum"
        }
      }
    ]`



