### PR TITLE
Correct 'repository' references in bad rows schemas

### DIFF
--- a/schemas/com.snowplowanalytics.snowplow.badrows/enrichment_failures/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.snowplow.badrows/enrichment_failures/jsonschema/1-0-0
@@ -104,9 +104,9 @@
                                 "items": {
                                   "type": "object",
                                   "properties": {
-                                    "repostitory": {
+                                    "repository": {
                                       "type": "string",
-                                      "description": "Name of the repostitory as written in resolver.json"
+                                      "description": "Name of the repository as written in resolver.json"
                                     },
                                     "errors": {
                                       "description": "Set of errors which happened for this repository",

--- a/schemas/com.snowplowanalytics.snowplow.badrows/enrichment_failures/jsonschema/2-0-0
+++ b/schemas/com.snowplowanalytics.snowplow.badrows/enrichment_failures/jsonschema/2-0-0
@@ -104,9 +104,9 @@
                                 "items": {
                                   "type": "object",
                                   "properties": {
-                                    "repostitory": {
+                                    "repository": {
                                       "type": "string",
-                                      "description": "Name of the repostitory as written in resolver.json"
+                                      "description": "Name of the repository as written in resolver.json"
                                     },
                                     "errors": {
                                       "description": "Set of errors which happened for this repository",

--- a/schemas/com.snowplowanalytics.snowplow.badrows/loader_iglu_error/jsonschema/2-0-0
+++ b/schemas/com.snowplowanalytics.snowplow.badrows/loader_iglu_error/jsonschema/2-0-0
@@ -37,9 +37,9 @@
                         "items": {
                           "type": "object",
                           "properties": {
-                            "repostitory": {
+                            "repository": {
                               "type": "string",
-                              "description": "Name of the repostitory as written in resolver.json"
+                              "description": "Name of the repository as written in resolver.json"
                             },
                             "errors": {
                               "description": "Set of errors which happened for this repository",
@@ -190,9 +190,9 @@
                         "items": {
                           "type": "object",
                           "properties": {
-                            "repostitory": {
+                            "repository": {
                               "type": "string",
-                              "description": "Name of the repostitory as written in resolver.json"
+                              "description": "Name of the repository as written in resolver.json"
                             },
                             "errors": {
                               "description": "Set of errors which happened for this repository",

--- a/schemas/com.snowplowanalytics.snowplow.badrows/schema_violations/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.snowplow.badrows/schema_violations/jsonschema/1-0-0
@@ -99,9 +99,9 @@
                             "items": {
                               "type": "object",
                               "properties": {
-                                "repostitory": {
+                                "repository": {
                                   "type": "string",
-                                  "description": "Name of the repostitory as written in resolver.json"
+                                  "description": "Name of the repository as written in resolver.json"
                                 },
                                 "errors": {
                                   "description": "Set of errors which happened for this repository",

--- a/schemas/com.snowplowanalytics.snowplow.badrows/schema_violations/jsonschema/2-0-0
+++ b/schemas/com.snowplowanalytics.snowplow.badrows/schema_violations/jsonschema/2-0-0
@@ -99,9 +99,9 @@
                             "items": {
                               "type": "object",
                               "properties": {
-                                "repostitory": {
+                                "repository": {
                                   "type": "string",
-                                  "description": "Name of the repostitory as written in resolver.json"
+                                  "description": "Name of the repository as written in resolver.json"
                                 },
                                 "errors": {
                                   "description": "Set of errors which happened for this repository",

--- a/schemas/com.snowplowanalytics.snowplow.badrows/tracker_protocol_violations/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.snowplow.badrows/tracker_protocol_violations/jsonschema/1-0-0
@@ -131,9 +131,9 @@
                             "items": {
                               "type": "object",
                               "properties": {
-                                "repostitory": {
+                                "repository": {
                                   "type": "string",
-                                  "description": "Name of the repostitory as written in resolver.json"
+                                  "description": "Name of the repository as written in resolver.json"
                                 },
                                 "errors": {
                                   "description": "Set of errors which happened for this repository",


### PR DESCRIPTION
There's a spelling error in a few of the bad rows schemas - the error exists in the schemas themselves but the upstream components have the correct spelling.

I'm not sure this is the best way to correct - by overriding the schema or if it's better to just go with a new model version for each of the schemas, though this would then result in having to update both the upstream and downstream dependencies.

For downstream dependencies I don't think there's many but https://github.com/snowplow-incubator/snowplow-badrows will be one of them.

cc @chuwy @benjben 