### PR TITLE
Add com.snowplowanalytics.mobile/deep_link_received/jsonschema/1-0-0 (close #1129)

### DIFF
--- a/schemas/com.snowplowanalytics.mobile/deep_link/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.mobile/deep_link/jsonschema/1-0-0
@@ -12,12 +12,12 @@
 		"url": {
 			"type": "string",
 			"description": "URL in the received deep-link",
-			"maxLength": 255
+			"maxLength": 4096
 		},
 		"referrer": {
 			"type": "string",
 			"description": "Referrer URL, source of this deep-link",
-			"maxLength": 255
+			"maxLength": 4096
 		}
 	},
 	"required": ["url"],

--- a/schemas/com.snowplowanalytics.mobile/deep_link/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.mobile/deep_link/jsonschema/1-0-0
@@ -12,11 +12,13 @@
 		"url": {
 			"type": "string",
 			"description": "URL in the received deep-link",
+			"format": "uri",
 			"maxLength": 4096
 		},
 		"referrer": {
 			"type": "string",
 			"description": "Referrer URL, source of this deep-link",
+			"format": "uri",
 			"maxLength": 4096
 		}
 	},

--- a/schemas/com.snowplowanalytics.mobile/deep_link/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.mobile/deep_link/jsonschema/1-0-0
@@ -1,0 +1,25 @@
+{
+	"$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+	"description": "Entity that indicates a deep-link has been received and processed.",
+	"self": {
+		"vendor": "com.snowplowanalytics.mobile",
+		"name": "deep_link",
+		"format": "jsonschema",
+		"version": "1-0-0"
+	},
+	"type": "object",
+	"properties": {
+		"url": {
+			"type": "string",
+			"description": "URL in the received deep-link",
+			"maxLength": 255
+		},
+		"referrer": {
+			"type": "string",
+			"description": "Referrer URL, source of this deep-link",
+			"maxLength": 255
+		}
+	},
+	"required": ["url"],
+	"additionalProperties": false
+}

--- a/schemas/com.snowplowanalytics.mobile/deep_link_received/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.mobile/deep_link_received/jsonschema/1-0-0
@@ -12,12 +12,12 @@
 		"url": {
 			"type": "string",
 			"description": "URL in the received deep-link",
-			"maxLength": 255
+			"maxLength": 4096
 		},
 		"referrer": {
 			"type": "string",
 			"description": "Referrer URL, source of this deep-link",
-			"maxLength": 255
+			"maxLength": 4096
 		}
 	},
 	"required": ["url"],

--- a/schemas/com.snowplowanalytics.mobile/deep_link_received/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.mobile/deep_link_received/jsonschema/1-0-0
@@ -1,0 +1,25 @@
+{
+	"$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+	"description": "Represents a deep-link received in the app.",
+	"self": {
+		"vendor": "com.snowplowanalytics.mobile",
+		"name": "deep_link_received",
+		"format": "jsonschema",
+		"version": "1-0-0"
+	},
+	"type": "object",
+	"properties": {
+		"url": {
+			"type": "string",
+			"description": "URL in the received deep-link",
+			"maxLength": 255
+		},
+		"referrer": {
+			"type": "string",
+			"description": "Referrer URL, source of this deep-link",
+			"maxLength": 255
+		}
+	},
+	"required": ["url"],
+	"additionalProperties": false
+}

--- a/schemas/com.snowplowanalytics.mobile/deep_link_received/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.mobile/deep_link_received/jsonschema/1-0-0
@@ -12,11 +12,13 @@
 		"url": {
 			"type": "string",
 			"description": "URL in the received deep-link",
+			"format": "uri",
 			"maxLength": 4096
 		},
 		"referrer": {
 			"type": "string",
 			"description": "Referrer URL, source of this deep-link",
+			"format": "uri",
 			"maxLength": 4096
 		}
 	},


### PR DESCRIPTION
As explained in the related issue, here are the two schemas for deep-link event and entity.
The event is tracked by the user and the entity is attached automatically by the tracker at the first ScreenView tracked.
This because the deep-link is mostly used to navigate inside the app from an external source, so the context will help the data modelling to identify which screen has been originated by a deep-link navigation.

For reference iOS PR: https://github.com/snowplow/snowplow-objc-tracker/pull/636