### PR TITLE
Feature/gtm server side

### DIFF
--- a/schemas/com.google.ga4.enhanced-measurement/click/jsonschema/1-0-0
+++ b/schemas/com.google.ga4.enhanced-measurement/click/jsonschema/1-0-0
@@ -1,0 +1,38 @@
+{
+        "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+        "self": {
+                "vendor": "com.google.ga4.enhanced-measurement",
+                "name": "click",
+                "version": "1-0-0",
+                "format": "jsonschema"
+        },
+        "description": "A click GA4 enhanced-measurement event.",
+        "type": "object",
+        "properties": {
+                "link_classes": {
+                        "description": "The classes of the link element.",
+                        "type": ["string", "null"],
+                        "maxLength": 4096
+                },
+                "link_domain": {
+                        "description": "The link domain.",
+                        "type": ["string", "null"],
+                        "maxLength": 4096
+                },
+                "link_id": {
+                        "description": "The link ID.",
+                        "type": ["string", "null"],
+                        "maxLength": 500
+                },
+                "link_url": {
+                        "description": "The link url.",
+                        "type": ["string", "null"],
+                        "maxLength": 4096
+                },
+                "outbound": {
+                        "description": "Whether the link is outbound.",
+                        "type": ["boolean", "null"]
+                }
+        },
+        "additionalProperties": false
+}

--- a/schemas/com.google.ga4.enhanced-measurement/file_download/jsonschema/1-0-0
+++ b/schemas/com.google.ga4.enhanced-measurement/file_download/jsonschema/1-0-0
@@ -1,0 +1,49 @@
+{
+        "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+        "self": {
+                "vendor": "com.google.ga4.enhanced-measurement",
+                "name": "file_download",
+                "version": "1-0-0",
+                "format": "jsonschema"
+        },
+        "description": "A file_download GA4 enhanced-measurement event.",
+        "type": "object",
+        "properties": {
+                "file_extention": {
+                        "description": "The extention of the file downloaded.",
+                        "type": ["string", "null"],
+                        "maxLength": 5
+                },
+                "file_name": {
+                        "description": "The file name.",
+                        "type": ["string", "null"],
+                        "maxLength": 500
+                },
+                "link_classes": {
+                        "description": "The classes of the file element.",
+                        "type": ["string", "null"],
+                        "maxLength": 4096
+                },
+                "link_domain": {
+                        "description": "The link domain.",
+                        "type": ["string", "null"],
+                        "maxLength": 4096
+                },
+                "link_id": {
+                        "description": "The link ID.",
+                        "type": ["string", "null"],
+                        "maxLength": 500
+                },
+                "link_text": {
+                        "description": "The link text.",
+                        "type": ["string", "null"],
+                        "maxLength": 4096
+                },
+                "link_url": {
+                        "description": "The link url.",
+                        "type": ["string", "null"],
+                        "maxLength": 4096
+                }
+        },
+        "additionalProperties": false
+}

--- a/schemas/com.google.ga4.enhanced-measurement/scroll/jsonschema/1-0-0
+++ b/schemas/com.google.ga4.enhanced-measurement/scroll/jsonschema/1-0-0
@@ -1,0 +1,13 @@
+{
+        "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+        "self": {
+                "vendor": "com.google.ga4.enhanced-measurement",
+                "name": "scroll",
+                "version": "1-0-0",
+                "format": "jsonschema"
+        },
+        "description": "A scroll GA4 enhanced-measurement event.",
+        "type": "object",
+        "properties": {},
+        "additionalProperties": false
+}

--- a/schemas/com.google.ga4.enhanced-measurement/video_complete/jsonschema/1-0-0
+++ b/schemas/com.google.ga4.enhanced-measurement/video_complete/jsonschema/1-0-0
@@ -1,0 +1,45 @@
+{
+        "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+        "self": {
+                "vendor": "com.google.ga4.enhanced-measurement",
+                "name": "video_complete",
+                "version": "1-0-0",
+                "format": "jsonschema"
+        },
+        "description": "A video_complete GA4 enhanced-measurement event.",
+        "type": "object",
+        "properties": {
+                "video_current_time": {
+                        "description": "The current time of the video.",
+                        "type": ["number", "null"]
+                },
+                "video_duration": {
+                        "description": "The video duration.",
+                        "type": ["number", "null"]
+                },
+                "video_percent": {
+                        "description": "The percentage of video watched.",
+                        "type": ["number", "null"]
+                },
+                "video_provider": {
+                        "description": "The video provider.",
+                        "type": ["string", "null"],
+                        "maxLength": 4096
+                },
+                "video_title": {
+                        "description": "The video title.",
+                        "type": ["string", "null"],
+                        "maxLength": 4096
+                },
+                "video_url": {
+                        "description": "The video url.",
+                        "type": ["string", "null"],
+                        "maxLength": 4096
+                },
+                "visible": {
+                        "description": "Whether the video is visible or not.",
+                        "type": ["boolean", "null"]
+                }
+        },
+        "additionalProperties": false
+}

--- a/schemas/com.google.ga4.enhanced-measurement/video_progress/jsonschema/1-0-0
+++ b/schemas/com.google.ga4.enhanced-measurement/video_progress/jsonschema/1-0-0
@@ -1,0 +1,45 @@
+{
+        "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+        "self": {
+                "vendor": "com.google.ga4.enhanced-measurement",
+                "name": "video_progress",
+                "version": "1-0-0",
+                "format": "jsonschema"
+        },
+        "description": "A video_progress GA4 enhanced-measurement event.",
+        "type": "object",
+        "properties": {
+                "video_current_time": {
+                        "description": "The current time of the video.",
+                        "type": ["number", "null"]
+                },
+                "video_duration": {
+                        "description": "The video duration.",
+                        "type": ["number", "null"]
+                },
+                "video_percent": {
+                        "description": "The percentage of video watched.",
+                        "type": ["number", "null"]
+                },
+                "video_provider": {
+                        "description": "The video provider.",
+                        "type": ["string", "null"],
+                        "maxLength": 4096
+                },
+                "video_title": {
+                        "description": "The video title.",
+                        "type": ["string", "null"],
+                        "maxLength": 4096
+                },
+                "video_url": {
+                        "description": "The video url.",
+                        "type": ["string", "null"],
+                        "maxLength": 4096
+                },
+                "visible": {
+                        "description": "Whether the video is visible or not.",
+                        "type": ["boolean", "null"]
+                }
+        },
+        "additionalProperties": false
+}

--- a/schemas/com.google.ga4.enhanced-measurement/video_start/jsonschema/1-0-0
+++ b/schemas/com.google.ga4.enhanced-measurement/video_start/jsonschema/1-0-0
@@ -1,0 +1,45 @@
+{
+        "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+        "self": {
+                "vendor": "com.google.ga4.enhanced-measurement",
+                "name": "video_start",
+                "version": "1-0-0",
+                "format": "jsonschema"
+        },
+        "description": "A video_start GA4 enhanced-measurement event.",
+        "type": "object",
+        "properties": {
+                "video_current_time": {
+                        "description": "The current time of the video.",
+                        "type": ["number", "null"]
+                },
+                "video_duration": {
+                        "description": "The video duration.",
+                        "type": ["number", "null"]
+                },
+                "video_percent": {
+                        "description": "The percentage of video watched.",
+                        "type": ["number", "null"]
+                },
+                "video_provider": {
+                        "description": "The video provider.",
+                        "type": ["string", "null"],
+                        "maxLength": 4096
+                },
+                "video_title": {
+                        "description": "The video title.",
+                        "type": ["string", "null"],
+                        "maxLength": 4096
+                },
+                "video_url": {
+                        "description": "The video url.",
+                        "type": ["string", "null"],
+                        "maxLength": 4096
+                },
+                "visible": {
+                        "description": "Whether the video is visible or not.",
+                        "type": ["boolean", "null"]
+                }
+        },
+        "additionalProperties": false
+}

--- a/schemas/com.google.ga4.enhanced-measurement/view_search_results/jsonschema/1-0-0
+++ b/schemas/com.google.ga4.enhanced-measurement/view_search_results/jsonschema/1-0-0
@@ -1,0 +1,19 @@
+{
+        "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+        "self": {
+                "vendor": "com.google.ga4.enhanced-measurement",
+                "name": "view_search_results",
+                "version": "1-0-0",
+                "format": "jsonschema"
+        },
+        "description": "A view_search_results GA4 enhanced-measurement event.",
+        "type": "object",
+        "properties": {
+                "search_term": {
+                        "description": "The term that was searched for.",
+                        "type": "string",
+                        "maxLength": 4096
+                }
+        },
+        "additionalProperties": false
+}

--- a/schemas/com.google.ga4/first_visit/jsonschema/1-0-0
+++ b/schemas/com.google.ga4/first_visit/jsonschema/1-0-0
@@ -1,0 +1,13 @@
+{
+        "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+        "self": {
+                "vendor": "com.google.ga4",
+                "name": "first_visit",
+                "version": "1-0-0",
+                "format": "jsonschema"
+        },
+        "description": "A first_visit GA4 event.",
+        "type": "object",
+        "properties": {},
+        "additionalProperties": false
+}

--- a/schemas/com.google.ga4/session_start/jsonschema/1-0-0
+++ b/schemas/com.google.ga4/session_start/jsonschema/1-0-0
@@ -1,0 +1,13 @@
+{
+        "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+        "self": {
+                "vendor": "com.google.ga4",
+                "name": "session_start",
+                "version": "1-0-0",
+                "format": "jsonschema"
+        },
+        "description": "A session_start GA4 event.",
+        "type": "object",
+        "properties": {},
+        "additionalProperties": false
+}

--- a/schemas/com.google.ga4/user_engagement/jsonschema/1-0-0
+++ b/schemas/com.google.ga4/user_engagement/jsonschema/1-0-0
@@ -1,0 +1,19 @@
+{
+        "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+        "self": {
+                "vendor": "com.google.ga4",
+                "name": "user_engagement",
+                "version": "1-0-0",
+                "format": "jsonschema"
+        },
+        "description": "A user_engagement GA4 event.",
+        "type": "object",
+        "properties": {
+                "engagement_time_msec": {
+                        "description": "The time in milliseconds that the user is engaged.",
+                        "type": ["number", "null"],
+                        "minimum": 0
+                }
+        },
+        "additionalProperties": false
+}

--- a/schemas/com.google.tag-manager.server-side/add_payment_info/jsonschema/1-0-0
+++ b/schemas/com.google.tag-manager.server-side/add_payment_info/jsonschema/1-0-0
@@ -1,0 +1,139 @@
+{
+        "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+        "self": {
+                "vendor": "com.google.tag-manager.server-side",
+                "name": "add_payment_info",
+                "version": "1-0-0",
+                "format": "jsonschema"
+        },
+        "description": "An add_payment_info GTM server-side event.",
+        "type": "object",
+        "properties": {
+                "currency": {
+                        "description": "Currency of the items associated with the event, in 3-letter ISO 4217 format. Is required, if value is set.",
+                        "type": ["string", "null"],
+                        "minLength": 3,
+                        "maxLength": 3
+                },
+                "value": {
+                        "description": "The monetary value of the event.",
+                        "type": ["number", "null"]
+                },
+                "coupon": {
+                        "description": "The coupon name or code associated with the event.",
+                        "type": ["string", "null"],
+                        "maxLength": 4096
+                },
+                "payment_type": {
+                        "description": "The chosen method of payment.",
+                        "type": ["string", "null"],
+                        "maxLength": 4096
+                },
+                "items": {
+                        "description": "The items for the event.",
+                        "type": "array",
+                        "items": {
+                                "description": "An item object.",
+                                "type": "object",
+                                "properties": {
+                                        "item_id": {
+                                                "description": "The ID of the item.",
+                                                "type": "string",
+                                                "maxLength": 500
+                                        },
+                                        "item_name": {
+                                                "description": "The name of the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 500
+                                        },
+                                        "affiliation": {
+                                                "description": "A product affiliation to designate a supplying company or brick and mortar store location",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "coupon": {
+                                                "description": "The coupon name or code associated with the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "currency": {
+                                                "description": "The currency, in 3-letter ISO 4217 format.",
+                                                "type": ["string", "null"],
+                                                "minLength": 3,
+                                                "maxLength": 3
+                                        },
+                                        "discount": {
+                                                "description": "The monetary discount value associated with the item.",
+                                                "type": ["number", "null"]
+                                        },
+                                        "index": {
+                                                "description": "The index of the item in a list.",
+                                                "type": ["number", "null"]
+                                        },
+                                        "item_brand": {
+                                                "description": "The brand of the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_category": {
+                                                "description": "The category of the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_category2": {
+                                                "description": "The second category hierarchy or additional taxonomy for the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_category3": {
+                                                "description": "The third category hierarchy or additional taxonomy for the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_category4": {
+                                                "description": "The fourth category hierarchy or additional taxonomy for the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_category5": {
+                                                "description": "The fifth category hierarchy or additional taxonomy for the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_list_id": {
+                                                "description": "The ID of the list in which the item was presented to the user.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_list_name": {
+                                                "description": "The name of the list in which the item was presented to the user.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_variant": {
+                                                "description": "The item variant or unique code or description for additional item details or options.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "location_id": {
+                                                "description": "The location associated with the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "price": {
+                                                "description": "The monetary price of the item, in units of the specified currency parameter.",
+                                                "type": ["number", "null"]
+                                        },
+                                        "quantity": {
+                                                "description": "Item quantity.",
+                                                "type": ["number", "null"]
+                                        }
+                                },
+                                "required": ["item_id"],
+                                "additionalProperties": false
+                        }
+                }
+        },
+        "required": ["items"],
+        "additionalProperties": false
+}

--- a/schemas/com.google.tag-manager.server-side/add_to_cart/jsonschema/1-0-0
+++ b/schemas/com.google.tag-manager.server-side/add_to_cart/jsonschema/1-0-0
@@ -1,0 +1,129 @@
+{
+        "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+        "self": {
+                "vendor": "com.google.tag-manager.server-side",
+                "name": "add_to_cart",
+                "version": "1-0-0",
+                "format": "jsonschema"
+        },
+        "description": "An add_to_cart GTM server-side event.",
+        "type": "object",
+        "properties": {
+                "currency": {
+                        "description": "Currency of the items associated with the event, in 3-letter ISO 4217 format. Is required, if value is set.",
+                        "type": ["string", "null"],
+                        "minLength": 3,
+                        "maxLength": 3
+                },
+                "value": {
+                        "description": "The monetary value of the event.",
+                        "type": ["number", "null"]
+                },
+                "items": {
+                        "description": "The items for the event.",
+                        "type": "array",
+                        "items": {
+                                "description": "An item object.",
+                                "type": "object",
+                                "properties": {
+                                        "item_id": {
+                                                "description": "The ID of the item.",
+                                                "type": "string",
+                                                "maxLength": 500
+                                        },
+                                        "item_name": {
+                                                "description": "The name of the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 500
+                                        },
+                                        "affiliation": {
+                                                "description": "A product affiliation to designate a supplying company or brick and mortar store location",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "coupon": {
+                                                "description": "The coupon name or code associated with the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "currency": {
+                                                "description": "The currency, in 3-letter ISO 4217 format.",
+                                                "type": ["string", "null"],
+                                                "minLength": 3,
+                                                "maxLength": 3
+                                        },
+                                        "discount": {
+                                                "description": "The monetary discount value associated with the item.",
+                                                "type": ["number", "null"]
+                                        },
+                                        "index": {
+                                                "description": "The index of the item in a list.",
+                                                "type": ["number", "null"]
+                                        },
+                                        "item_brand": {
+                                                "description": "The brand of the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_category": {
+                                                "description": "The category of the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_category2": {
+                                                "description": "The second category hierarchy or additional taxonomy for the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_category3": {
+                                                "description": "The third category hierarchy or additional taxonomy for the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_category4": {
+                                                "description": "The fourth category hierarchy or additional taxonomy for the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_category5": {
+                                                "description": "The fifth category hierarchy or additional taxonomy for the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_list_id": {
+                                                "description": "The ID of the list in which the item was presented to the user.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_list_name": {
+                                                "description": "The name of the list in which the item was presented to the user.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_variant": {
+                                                "description": "The item variant or unique code or description for additional item details or options.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "location_id": {
+                                                "description": "The location associated with the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "price": {
+                                                "description": "The monetary price of the item, in units of the specified currency parameter.",
+                                                "type": ["number", "null"]
+                                        },
+                                        "quantity": {
+                                                "description": "Item quantity.",
+                                                "type": ["number", "null"]
+                                        }
+                                },
+                                "required": ["item_id"],
+                                "additionalProperties": false
+                        }
+                }
+        },
+        "required": ["items"],
+        "additionalProperties": false
+}

--- a/schemas/com.google.tag-manager.server-side/add_to_wishlist/jsonschema/1-0-0
+++ b/schemas/com.google.tag-manager.server-side/add_to_wishlist/jsonschema/1-0-0
@@ -1,0 +1,129 @@
+{
+        "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+        "self": {
+                "vendor": "com.google.tag-manager.server-side",
+                "name": "add_to_wishlist",
+                "version": "1-0-0",
+                "format": "jsonschema"
+        },
+        "description": "An add_to_wishlist GTM server-side event.",
+        "type": "object",
+        "properties": {
+                "currency": {
+                        "description": "Currency of the items associated with the event, in 3-letter ISO 4217 format. Is required, if value is set.",
+                        "type": ["string", "null"],
+                        "minLength": 3,
+                        "maxLength": 3
+                },
+                "value": {
+                        "description": "The monetary value of the event.",
+                        "type": ["number", "null"]
+                },
+                "items": {
+                        "description": "The items for the event.",
+                        "type": "array",
+                        "items": {
+                                "description": "An item object.",
+                                "type": "object",
+                                "properties": {
+                                        "item_id": {
+                                                "description": "The ID of the item.",
+                                                "type": "string",
+                                                "maxLength": 500
+                                        },
+                                        "item_name": {
+                                                "description": "The name of the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 500
+                                        },
+                                        "affiliation": {
+                                                "description": "A product affiliation to designate a supplying company or brick and mortar store location",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "coupon": {
+                                                "description": "The coupon name or code associated with the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "currency": {
+                                                "description": "The currency, in 3-letter ISO 4217 format.",
+                                                "type": ["string", "null"],
+                                                "minLength": 3,
+                                                "maxLength": 3
+                                        },
+                                        "discount": {
+                                                "description": "The monetary discount value associated with the item.",
+                                                "type": ["number", "null"]
+                                        },
+                                        "index": {
+                                                "description": "The index of the item in a list.",
+                                                "type": ["number", "null"]
+                                        },
+                                        "item_brand": {
+                                                "description": "The brand of the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_category": {
+                                                "description": "The category of the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_category2": {
+                                                "description": "The second category hierarchy or additional taxonomy for the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_category3": {
+                                                "description": "The third category hierarchy or additional taxonomy for the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_category4": {
+                                                "description": "The fourth category hierarchy or additional taxonomy for the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_category5": {
+                                                "description": "The fifth category hierarchy or additional taxonomy for the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_list_id": {
+                                                "description": "The ID of the list in which the item was presented to the user.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_list_name": {
+                                                "description": "The name of the list in which the item was presented to the user.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_variant": {
+                                                "description": "The item variant or unique code or description for additional item details or options.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "location_id": {
+                                                "description": "The location associated with the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "price": {
+                                                "description": "The monetary price of the item, in units of the specified currency parameter.",
+                                                "type": ["number", "null"]
+                                        },
+                                        "quantity": {
+                                                "description": "Item quantity.",
+                                                "type": ["number", "null"]
+                                        }
+                                },
+                                "required": ["item_id"],
+                                "additionalProperties": false
+                        }
+                }
+        },
+        "required": ["items"],
+        "additionalProperties": false
+}

--- a/schemas/com.google.tag-manager.server-side/begin_checkout/jsonschema/1-0-0
+++ b/schemas/com.google.tag-manager.server-side/begin_checkout/jsonschema/1-0-0
@@ -1,0 +1,134 @@
+{
+        "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+        "self": {
+                "vendor": "com.google.tag-manager.server-side",
+                "name": "begin_checkout",
+                "version": "1-0-0",
+                "format": "jsonschema"
+        },
+        "description": "A begin_checkout GTM server-side event.",
+        "type": "object",
+        "properties": {
+                "currency": {
+                        "description": "Currency of the items associated with the event, in 3-letter ISO 4217 format. Is required, if value is set.",
+                        "type": ["string", "null"],
+                        "minLength": 3,
+                        "maxLength": 3
+                },
+                "value": {
+                        "description": "The monetary value of the event.",
+                        "type": ["number", "null"]
+                },
+                "coupon": {
+                        "description": "The coupon name or code associated with the event.",
+                        "type": ["string", "null"],
+                        "maxLength": 4096
+                },
+                "items": {
+                        "description": "The items for the event.",
+                        "type": "array",
+                        "items": {
+                                "description": "An item object.",
+                                "type": "object",
+                                "properties": {
+                                        "item_id": {
+                                                "description": "The ID of the item.",
+                                                "type": "string",
+                                                "maxLength": 500
+                                        },
+                                        "item_name": {
+                                                "description": "The name of the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 500
+                                        },
+                                        "affiliation": {
+                                                "description": "A product affiliation to designate a supplying company or brick and mortar store location",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "coupon": {
+                                                "description": "The coupon name or code associated with the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "currency": {
+                                                "description": "The currency, in 3-letter ISO 4217 format.",
+                                                "type": ["string", "null"],
+                                                "minLength": 3,
+                                                "maxLength": 3
+                                        },
+                                        "discount": {
+                                                "description": "The monetary discount value associated with the item.",
+                                                "type": ["number", "null"]
+                                        },
+                                        "index": {
+                                                "description": "The index of the item in a list.",
+                                                "type": ["number", "null"]
+                                        },
+                                        "item_brand": {
+                                                "description": "The brand of the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_category": {
+                                                "description": "The category of the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_category2": {
+                                                "description": "The second category hierarchy or additional taxonomy for the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_category3": {
+                                                "description": "The third category hierarchy or additional taxonomy for the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_category4": {
+                                                "description": "The fourth category hierarchy or additional taxonomy for the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_category5": {
+                                                "description": "The fifth category hierarchy or additional taxonomy for the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_list_id": {
+                                                "description": "The ID of the list in which the item was presented to the user.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_list_name": {
+                                                "description": "The name of the list in which the item was presented to the user.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_variant": {
+                                                "description": "The item variant or unique code or description for additional item details or options.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "location_id": {
+                                                "description": "The location associated with the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "price": {
+                                                "description": "The monetary price of the item, in units of the specified currency parameter.",
+                                                "type": ["number", "null"]
+                                        },
+                                        "quantity": {
+                                                "description": "Item quantity.",
+                                                "type": ["number", "null"]
+                                        }
+                                },
+                                "required": ["item_id"],
+                                "additionalProperties": false
+                        }
+                }
+        },
+        "required": ["items"],
+        "additionalProperties": false
+}

--- a/schemas/com.google.tag-manager.server-side/exception/jsonschema/1-0-0
+++ b/schemas/com.google.tag-manager.server-side/exception/jsonschema/1-0-0
@@ -1,0 +1,24 @@
+{
+        "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+        "self": {
+                "vendor": "com.google.tag-manager.server-side",
+                "name": "exception",
+                "version": "1-0-0",
+                "format": "jsonschema"
+        },
+        "description": "An exception GTM server-side event.",
+        "type": "object",
+        "properties": {
+                "description": {
+                        "description": "The description of the exception that occurred.",
+                        "type": ["string", "null"],
+                        "maxLength": 4096
+                },
+                "fatal": {
+                        "description": "Whether or not the exception was a fatal one.",
+                        "type": ["boolean", "null"]
+                }
+
+        },
+        "additionalProperties": false
+}

--- a/schemas/com.google.tag-manager.server-side/generate_lead/jsonschema/1-0-0
+++ b/schemas/com.google.tag-manager.server-side/generate_lead/jsonschema/1-0-0
@@ -1,0 +1,24 @@
+{
+        "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+        "self": {
+                "vendor": "com.google.tag-manager.server-side",
+                "name": "generate_lead",
+                "version": "1-0-0",
+                "format": "jsonschema"
+        },
+        "description": "A generate_lead GTM server-side event.",
+        "type": "object",
+        "properties": {
+                "currency": {
+                        "description": "Currency of the items associated with the event, in 3-letter ISO 4217 format. Is required, if value is set.",
+                        "type": ["string", "null"],
+                        "minLength": 3,
+                        "maxLength": 3
+                },
+                "value": {
+                        "description": "The monetary value of the event.",
+                        "type": ["number", "null"]
+                }
+        },
+        "additionalProperties": false
+}

--- a/schemas/com.google.tag-manager.server-side/join_group/jsonschema/1-0-0
+++ b/schemas/com.google.tag-manager.server-side/join_group/jsonschema/1-0-0
@@ -1,0 +1,19 @@
+{
+        "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+        "self": {
+                "vendor": "com.google.tag-manager.server-side",
+                "name": "join_group",
+                "version": "1-0-0",
+                "format": "jsonschema"
+        },
+        "description": "A join_group GTM server-side event.",
+        "type": "object",
+        "properties": {
+                "group_id": {
+                        "description": "The ID of the group.",
+                        "type": ["string", "null"],
+                        "maxLength": 4096
+                }
+        },
+        "additionalProperties": false
+}

--- a/schemas/com.google.tag-manager.server-side/login/jsonschema/1-0-0
+++ b/schemas/com.google.tag-manager.server-side/login/jsonschema/1-0-0
@@ -1,0 +1,19 @@
+{
+        "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+        "self": {
+                "vendor": "com.google.tag-manager.server-side",
+                "name": "login",
+                "version": "1-0-0",
+                "format": "jsonschema"
+        },
+        "description": "A login GTM server-side event.",
+        "type": "object",
+        "properties": {
+                "method": {
+                        "description": "The method used to login.",
+                        "type": ["string", "null"],
+                        "maxLength": 4096
+                }
+        },
+        "additionalProperties": false
+}

--- a/schemas/com.google.tag-manager.server-side/purchase/jsonschema/1-0-0
+++ b/schemas/com.google.tag-manager.server-side/purchase/jsonschema/1-0-0
@@ -1,0 +1,155 @@
+{
+        "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+        "self": {
+                "vendor": "com.google.tag-manager.server-side",
+                "name": "purchase",
+                "version": "1-0-0",
+                "format": "jsonschema"
+        },
+        "description": "A purchase GTM server-side event.",
+        "type": "object",
+        "properties": {
+                "currency": {
+                        "description": "Currency of the items associated with the event, in 3-letter ISO 4217 format. Is required, if value is set.",
+                        "type": ["string", "null"],
+                        "minLength": 3,
+                        "maxLength": 3
+                },
+                "transaction_id": {
+                        "description": "The unique identifier of a transaction.",
+                        "type": "string",
+                        "maxLength": 500
+                },
+                "value": {
+                        "description": "The monetary value of the event.",
+                        "type": ["number", "null"]
+                },
+                "affiliation": {
+                        "description": "A product affiliation to designate a supplying company or brick and mortar store location.",
+                        "type": ["string", "null"],
+                        "maxLength": 4096
+                },
+                "coupon": {
+                        "description": "The coupon name or code associated with the event.",
+                        "type": ["string", "null"],
+                        "maxLength": 4096
+                },
+                "shipping": {
+                        "description": "Shipping cost associated with a transaction.",
+                        "type": ["number", "null"]
+                },
+                "tax": {
+                        "description": "Tax cost associated with a transaction.",
+                        "type": ["number", "null"]
+                },
+                "items": {
+                        "description": "The items for the event.",
+                        "type": "array",
+                        "items": {
+                                "description": "An item object.",
+                                "type": "object",
+                                "properties": {
+                                        "item_id": {
+                                                "description": "The ID of the item.",
+                                                "type": "string",
+                                                "maxLength": 500
+                                        },
+                                        "item_name": {
+                                                "description": "The name of the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 500
+                                        },
+                                        "affiliation": {
+                                                "description": "A product affiliation to designate a supplying company or brick and mortar store location",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "coupon": {
+                                                "description": "The coupon name or code associated with the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "currency": {
+                                                "description": "The currency, in 3-letter ISO 4217 format.",
+                                                "type": ["string", "null"],
+                                                "minLength": 3,
+                                                "maxLength": 3
+                                        },
+                                        "discount": {
+                                                "description": "The monetary discount value associated with the item.",
+                                                "type": ["number", "null"]
+                                        },
+                                        "index": {
+                                                "description": "The index of the item in a list.",
+                                                "type": ["number", "null"]
+                                        },
+                                        "item_brand": {
+                                                "description": "The brand of the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_category": {
+                                                "description": "The category of the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_category2": {
+                                                "description": "The second category hierarchy or additional taxonomy for the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_category3": {
+                                                "description": "The third category hierarchy or additional taxonomy for the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_category4": {
+                                                "description": "The fourth category hierarchy or additional taxonomy for the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_category5": {
+                                                "description": "The fifth category hierarchy or additional taxonomy for the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_list_id": {
+                                                "description": "The ID of the list in which the item was presented to the user.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_list_name": {
+                                                "description": "The name of the list in which the item was presented to the user.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_variant": {
+                                                "description": "The item variant or unique code or description for additional item details or options.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "location_id": {
+                                                "description": "The location associated with the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "price": {
+                                                "description": "The monetary price of the item, in units of the specified currency parameter.",
+                                                "type": ["number", "null"]
+                                        },
+                                        "quantity": {
+                                                "description": "Item quantity.",
+                                                "type": ["number", "null"]
+                                        }
+                                },
+                                "required": ["item_id"],
+                                "additionalProperties": false
+                        }
+                }
+        },
+        "required": [
+                "transaction_id",
+                "items"
+        ],
+        "additionalProperties": false
+}

--- a/schemas/com.google.tag-manager.server-side/refund/jsonschema/1-0-0
+++ b/schemas/com.google.tag-manager.server-side/refund/jsonschema/1-0-0
@@ -1,0 +1,152 @@
+{
+        "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+        "self": {
+                "vendor": "com.google.tag-manager.server-side",
+                "name": "refund",
+                "version": "1-0-0",
+                "format": "jsonschema"
+        },
+        "description": "A refund GTM server-side event.",
+        "type": "object",
+        "properties": {
+                "currency": {
+                        "description": "Currency of the items associated with the event, in 3-letter ISO 4217 format. Is required, if value is set.",
+                        "type": ["string", "null"],
+                        "minLength": 3,
+                        "maxLength": 3
+                },
+                "transaction_id": {
+                        "description": "The unique identifier of a transaction.",
+                        "type": "string",
+                        "maxLength": 500
+                },
+                "value": {
+                        "description": "The monetary value of the event.",
+                        "type": ["number", "null"]
+                },
+                "affiliation": {
+                        "description": "A product affiliation to designate a supplying company or brick and mortar store location.",
+                        "type": ["string", "null"],
+                        "maxLength": 4096
+                },
+                "coupon": {
+                        "description": "The coupon name or code associated with the event.",
+                        "type": ["string", "null"],
+                        "maxLength": 4096
+                },
+                "shipping": {
+                        "description": "Shipping cost associated with a transaction.",
+                        "type": ["number", "null"]
+                },
+                "tax": {
+                        "description": "Tax cost associated with a transaction.",
+                        "type": ["number", "null"]
+                },
+                "items": {
+                        "description": "The items for the event.",
+                        "type": ["array", "null"],
+                        "items": {
+                                "description": "An item object.",
+                                "type": "object",
+                                "properties": {
+                                        "item_id": {
+                                                "description": "The ID of the item.",
+                                                "type": "string",
+                                                "maxLength": 500
+                                        },
+                                        "item_name": {
+                                                "description": "The name of the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 500
+                                        },
+                                        "affiliation": {
+                                                "description": "A product affiliation to designate a supplying company or brick and mortar store location",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "coupon": {
+                                                "description": "The coupon name or code associated with the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "currency": {
+                                                "description": "The currency, in 3-letter ISO 4217 format.",
+                                                "type": ["string", "null"],
+                                                "minLength": 3,
+                                                "maxLength": 3
+                                        },
+                                        "discount": {
+                                                "description": "The monetary discount value associated with the item.",
+                                                "type": ["number", "null"]
+                                        },
+                                        "index": {
+                                                "description": "The index of the item in a list.",
+                                                "type": ["number", "null"]
+                                        },
+                                        "item_brand": {
+                                                "description": "The brand of the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_category": {
+                                                "description": "The category of the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_category2": {
+                                                "description": "The second category hierarchy or additional taxonomy for the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_category3": {
+                                                "description": "The third category hierarchy or additional taxonomy for the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_category4": {
+                                                "description": "The fourth category hierarchy or additional taxonomy for the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_category5": {
+                                                "description": "The fifth category hierarchy or additional taxonomy for the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_list_id": {
+                                                "description": "The ID of the list in which the item was presented to the user.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_list_name": {
+                                                "description": "The name of the list in which the item was presented to the user.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_variant": {
+                                                "description": "The item variant or unique code or description for additional item details or options.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "location_id": {
+                                                "description": "The location associated with the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "price": {
+                                                "description": "The monetary price of the item, in units of the specified currency parameter.",
+                                                "type": ["number", "null"]
+                                        },
+                                        "quantity": {
+                                                "description": "Item quantity.",
+                                                "type": ["number", "null"]
+                                        }
+                                },
+                                "required": ["item_id"],
+                                "additionalProperties": false
+                        }
+                }
+        },
+        "required": ["transaction_id"],
+        "additionalProperties": false
+}

--- a/schemas/com.google.tag-manager.server-side/search/jsonschema/1-0-0
+++ b/schemas/com.google.tag-manager.server-side/search/jsonschema/1-0-0
@@ -1,0 +1,20 @@
+{
+        "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+        "self": {
+                "vendor": "com.google.tag-manager.server-side",
+                "name": "search",
+                "version": "1-0-0",
+                "format": "jsonschema"
+        },
+        "description": "A search GTM server-side event.",
+        "type": "object",
+        "properties": {
+                "search_term": {
+                        "description": "The term that was searched for.",
+                        "type": "string",
+                        "maxLength": 4096
+                }
+        },
+        "required": ["search_term"],
+        "additionalProperties": false
+}

--- a/schemas/com.google.tag-manager.server-side/select_content/jsonschema/1-0-0
+++ b/schemas/com.google.tag-manager.server-side/select_content/jsonschema/1-0-0
@@ -1,0 +1,24 @@
+{
+        "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+        "self": {
+                "vendor": "com.google.tag-manager.server-side",
+                "name": "select_content",
+                "version": "1-0-0",
+                "format": "jsonschema"
+        },
+        "description": "A select_content GTM server-side event.",
+        "type": "object",
+        "properties": {
+                "content_type": {
+                        "description": "The type of selected content.",
+                        "type": ["string", "null"],
+                        "maxLength": 4096
+                },
+                "item_id": {
+                        "description": "An identifier for the item that was selected.",
+                        "type": ["string", "null"],
+                        "maxLength": 500
+                }
+        },
+        "additionalProperties": false
+}

--- a/schemas/com.google.tag-manager.server-side/share/jsonschema/1-0-0
+++ b/schemas/com.google.tag-manager.server-side/share/jsonschema/1-0-0
@@ -1,0 +1,29 @@
+{
+        "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+        "self": {
+                "vendor": "com.google.tag-manager.server-side",
+                "name": "share",
+                "version": "1-0-0",
+                "format": "jsonschema"
+        },
+        "description": "A share GTM server-side event.",
+        "type": "object",
+        "properties": {
+                "method": {
+                        "description": "The method in which the content is shared.",
+                        "type": ["string", "null"],
+                        "maxLength": 4096
+                },
+                "content_type": {
+                        "description": "The type of selected content.",
+                        "type": ["string", "null"],
+                        "maxLength": 4096
+                },
+                "item_id": {
+                        "description": "An identifier for the item that was selected.",
+                        "type": ["string", "null"],
+                        "maxLength": 500
+                }
+        },
+        "additionalProperties": false
+}

--- a/schemas/com.google.tag-manager.server-side/sign_up/jsonschema/1-0-0
+++ b/schemas/com.google.tag-manager.server-side/sign_up/jsonschema/1-0-0
@@ -1,0 +1,19 @@
+{
+        "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+        "self": {
+                "vendor": "com.google.tag-manager.server-side",
+                "name": "sign_up",
+                "version": "1-0-0",
+                "format": "jsonschema"
+        },
+        "description": "An sign_up GTM server-side event.",
+        "type": "object",
+        "properties": {
+                "method": {
+                        "description": "The method used for sign up.",
+                        "type": ["string", "null"],
+                        "maxLength": 4096
+                }
+        },
+        "additionalProperties": false
+}

--- a/schemas/com.google.tag-manager.server-side/view_item/jsonschema/1-0-0
+++ b/schemas/com.google.tag-manager.server-side/view_item/jsonschema/1-0-0
@@ -1,0 +1,129 @@
+{
+        "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+        "self": {
+                "vendor": "com.google.tag-manager.server-side",
+                "name": "view_item",
+                "version": "1-0-0",
+                "format": "jsonschema"
+        },
+        "description": "A view_item GTM server-side event.",
+        "type": "object",
+        "properties": {
+                "currency": {
+                        "description": "Currency of the items associated with the event, in 3-letter ISO 4217 format. Is required, if value is set.",
+                        "type": ["string", "null"],
+                        "minLength": 3,
+                        "maxLength": 3
+                },
+                "value": {
+                        "description": "The monetary value of the event.",
+                        "type": ["number", "null"]
+                },
+                "items": {
+                        "description": "The items for the event.",
+                        "type": "array",
+                        "items": {
+                                "description": "An item object.",
+                                "type": "object",
+                                "properties": {
+                                        "item_id": {
+                                                "description": "The ID of the item.",
+                                                "type": "string",
+                                                "maxLength": 500
+                                        },
+                                        "item_name": {
+                                                "description": "The name of the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 500
+                                        },
+                                        "affiliation": {
+                                                "description": "A product affiliation to designate a supplying company or brick and mortar store location",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "coupon": {
+                                                "description": "The coupon name or code associated with the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "currency": {
+                                                "description": "The currency, in 3-letter ISO 4217 format.",
+                                                "type": ["string", "null"],
+                                                "minLength": 3,
+                                                "maxLength": 3
+                                        },
+                                        "discount": {
+                                                "description": "The monetary discount value associated with the item.",
+                                                "type": ["number", "null"]
+                                        },
+                                        "index": {
+                                                "description": "The index of the item in a list.",
+                                                "type": ["number", "null"]
+                                        },
+                                        "item_brand": {
+                                                "description": "The brand of the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_category": {
+                                                "description": "The category of the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_category2": {
+                                                "description": "The second category hierarchy or additional taxonomy for the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_category3": {
+                                                "description": "The third category hierarchy or additional taxonomy for the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_category4": {
+                                                "description": "The fourth category hierarchy or additional taxonomy for the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_category5": {
+                                                "description": "The fifth category hierarchy or additional taxonomy for the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_list_id": {
+                                                "description": "The ID of the list in which the item was presented to the user.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_list_name": {
+                                                "description": "The name of the list in which the item was presented to the user.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_variant": {
+                                                "description": "The item variant or unique code or description for additional item details or options.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "location_id": {
+                                                "description": "The location associated with the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "price": {
+                                                "description": "The monetary price of the item, in units of the specified currency parameter.",
+                                                "type": ["number", "null"]
+                                        },
+                                        "quantity": {
+                                                "description": "Item quantity.",
+                                                "type": ["number", "null"]
+                                        }
+                                },
+                                "required": ["item_id"],
+                                "additionalProperties": false
+                        }
+                }
+        },
+        "required": ["items"],
+        "additionalProperties": false
+}

--- a/schemas/com.google.tag-manager.server-side/view_item_list/jsonschema/1-0-0
+++ b/schemas/com.google.tag-manager.server-side/view_item_list/jsonschema/1-0-0
@@ -1,0 +1,129 @@
+{
+        "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+        "self": {
+                "vendor": "com.google.tag-manager.server-side",
+                "name": "view_item_list",
+                "version": "1-0-0",
+                "format": "jsonschema"
+        },
+        "description": "A view_item_list GTM server-side event.",
+        "type": "object",
+        "properties": {
+                "item_list_id": {
+                        "description": "The ID of the list in which the item was presented to the user.",
+                        "type": ["string", "null"],
+                        "maxLength": 4096
+                },
+                "item_list_name": {
+                        "description": "The name of the list in which the item was presented to the user.",
+                        "type": ["string", "null"],
+                        "maxLength": 4096
+                },
+                "items": {
+                        "description": "The items for the event.",
+                        "type": "array",
+                        "items": {
+                                "description": "An item object.",
+                                "type": "object",
+                                "properties": {
+                                        "item_id": {
+                                                "description": "The ID of the item.",
+                                                "type": "string",
+                                                "maxLength": 500
+                                        },
+                                        "item_name": {
+                                                "description": "The name of the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 500
+                                        },
+                                        "affiliation": {
+                                                "description": "A product affiliation to designate a supplying company or brick and mortar store location",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "coupon": {
+                                                "description": "The coupon name or code associated with the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "currency": {
+                                                "description": "The currency, in 3-letter ISO 4217 format.",
+                                                "type": ["string", "null"],
+                                                "minLength": 3,
+                                                "maxLength": 3
+                                        },
+                                        "discount": {
+                                                "description": "The monetary discount value associated with the item.",
+                                                "type": ["number", "null"]
+                                        },
+                                        "index": {
+                                                "description": "The index of the item in a list.",
+                                                "type": ["number", "null"]
+                                        },
+                                        "item_brand": {
+                                                "description": "The brand of the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_category": {
+                                                "description": "The category of the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_category2": {
+                                                "description": "The second category hierarchy or additional taxonomy for the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_category3": {
+                                                "description": "The third category hierarchy or additional taxonomy for the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_category4": {
+                                                "description": "The fourth category hierarchy or additional taxonomy for the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_category5": {
+                                                "description": "The fifth category hierarchy or additional taxonomy for the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_list_id": {
+                                                "description": "The ID of the list in which the item was presented to the user.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_list_name": {
+                                                "description": "The name of the list in which the item was presented to the user.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_variant": {
+                                                "description": "The item variant or unique code or description for additional item details or options.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "location_id": {
+                                                "description": "The location associated with the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "price": {
+                                                "description": "The monetary price of the item, in units of the specified currency parameter.",
+                                                "type": ["number", "null"]
+                                        },
+                                        "quantity": {
+                                                "description": "Item quantity.",
+                                                "type": ["number", "null"]
+                                        }
+                                },
+                                "required": ["item_id"],
+                                "additionalProperties": false
+                        }
+                }
+        },
+        "required": ["items"],
+        "additionalProperties": false
+}

--- a/schemas/com.google.tag-manager.server-side/view_search_results/jsonschema/1-0-0
+++ b/schemas/com.google.tag-manager.server-side/view_search_results/jsonschema/1-0-0
@@ -1,0 +1,123 @@
+{
+        "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+        "self": {
+                "vendor": "com.google.tag-manager.server-side",
+                "name": "view_search_results",
+                "version": "1-0-0",
+                "format": "jsonschema"
+        },
+        "description": "A view_search_results GTM server-side event.",
+        "type": "object",
+        "properties": {
+                "search_term": {
+                        "description": "The term that was searched for.",
+                        "type": "string",
+                        "maxLength": 4096
+                },
+                "items": {
+                        "description": "The items for the event.",
+                        "type": ["array", "null"],
+                        "items": {
+                                "description": "An item object.",
+                                "type": "object",
+                                "properties": {
+                                        "item_id": {
+                                                "description": "The ID of the item.",
+                                                "type": "string",
+                                                "maxLength": 500
+                                        },
+                                        "item_name": {
+                                                "description": "The name of the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 500
+                                        },
+                                        "affiliation": {
+                                                "description": "A product affiliation to designate a supplying company or brick and mortar store location",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "coupon": {
+                                                "description": "The coupon name or code associated with the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "currency": {
+                                                "description": "The currency, in 3-letter ISO 4217 format.",
+                                                "type": ["string", "null"],
+                                                "minLength": 3,
+                                                "maxLength": 3
+                                        },
+                                        "discount": {
+                                                "description": "The monetary discount value associated with the item.",
+                                                "type": ["number", "null"]
+                                        },
+                                        "index": {
+                                                "description": "The index of the item in a list.",
+                                                "type": ["number", "null"]
+                                        },
+                                        "item_brand": {
+                                                "description": "The brand of the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_category": {
+                                                "description": "The category of the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_category2": {
+                                                "description": "The second category hierarchy or additional taxonomy for the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_category3": {
+                                                "description": "The third category hierarchy or additional taxonomy for the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_category4": {
+                                                "description": "The fourth category hierarchy or additional taxonomy for the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_category5": {
+                                                "description": "The fifth category hierarchy or additional taxonomy for the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_list_id": {
+                                                "description": "The ID of the list in which the item was presented to the user.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_list_name": {
+                                                "description": "The name of the list in which the item was presented to the user.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "item_variant": {
+                                                "description": "The item variant or unique code or description for additional item details or options.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "location_id": {
+                                                "description": "The location associated with the item.",
+                                                "type": ["string", "null"],
+                                                "maxLength": 4096
+                                        },
+                                        "price": {
+                                                "description": "The monetary price of the item, in units of the specified currency parameter.",
+                                                "type": ["number", "null"]
+                                        },
+                                        "quantity": {
+                                                "description": "Item quantity.",
+                                                "type": ["number", "null"]
+                                        }
+                                },
+                                "required": ["item_id"],
+                                "additionalProperties": false
+                        }
+                }
+        },
+        "additionalProperties": false
+}


### PR DESCRIPTION
This PR includes the schemas that will be used by the gtm server-side Snowplow tag and should correspond to the respective gtm-server-side and ga4 events.
The events refer to:

 - [Server side events](https://developers.google.com/tag-manager/serverside/events)
 - [GA4 Enhanced measurement events](https://support.google.com/analytics/answer/9216061?hl=en&ref_topic=9756175)
 - [GA4 automatically collected events for web](https://support.google.com/analytics/answer/9234069?hl=en&ref_topic=9756175)
 
A detailed documentation for all the parameters in order to definitely set stringLengths, or a clear indication about the differences between measurement protocol v1 and v2 in terms of type restrictions seems to be missing.
For some of those parameters, there is information in the Measurement protocol v1 [parameters](https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters) and [reference](https://developers.google.com/analytics/devguides/collection/protocol/v1/reference) and the v2 (e.g. [here](https://developers.google.com/analytics/devguides/collection/protocol/ga4/sending-events?client_type=gtag#limitations))

That is why, the max string length was set to `4096` for most properties, except for:
 - currency (3)
 -  file_extension (5)
 - any "id" property's: item_id, item_name, transaction_id, link_id, file_name (500)
