### PR TITLE
Add properties for memory, battery, and storage info into mobile context (close #1168)

### DIFF
--- a/schemas/com.snowplowanalytics.snowplow/mobile_context/jsonschema/1-0-2
+++ b/schemas/com.snowplowanalytics.snowplow/mobile_context/jsonschema/1-0-2
@@ -1,0 +1,95 @@
+{
+	"$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+	"description": "Schema for mobile contexts",
+	"self": {
+		"vendor": "com.snowplowanalytics.snowplow",
+		"name": "mobile_context",
+		"format": "jsonschema",
+		"version": "1-0-2"
+	},
+	"type": "object",
+	"properties": {
+		"osType": {
+			"type": "string"
+		},
+		"osVersion": {
+			"type": "string"
+		},
+		"deviceManufacturer": {
+			"type": "string"
+		},
+		"deviceModel": {
+			"type": "string"
+		},
+		"carrier": {
+			"type": ["string", "null"]
+		},
+		"networkType": {
+			"type": ["string", "null"],
+			"enum": ["mobile", "wifi", "offline"]
+		},
+		"networkTechnology": {
+			"type": ["string", "null"]
+		},
+		"openIdfa": {
+			"type": ["string", "null"]
+		},
+		"appleIdfa": {
+			"type": ["string", "null"]
+		},
+		"appleIdfv": {
+			"type": ["string", "null"]
+		},
+		"androidIdfa": {
+			"type": ["string", "null"]
+		},
+		"physicalMemory": {
+			"type": ["integer", "null"],
+			"minimum": 0,
+			"maximum": 9223372036854775807,
+			"description": "Total physical system memory in bytes"
+		},
+		"systemAvailableMemory": {
+			"type": ["integer", "null"],
+			"minimum": 0,
+			"maximum": 9223372036854775807,
+			"description": "Available memory on the system in bytes (Android only)"
+		},
+		"appAvailableMemory": {
+			"type": ["integer", "null"],
+			"minimum": 0,
+			"maximum": 4294967295,
+			"description": "Amount of memory in bytes available to the current app (iOS only)"
+		},
+		"batteryLevel": {
+			"type": ["integer", "null"],
+			"minimum": 0,
+			"maximum": 100,
+			"description": "Remaining battery level as an integer percentage of total battery capacity"
+		},
+		"batteryState": {
+			"type": ["string", "null"],
+			"enum": ["unplugged", "charging", "full"],
+			"maxLength": 255,
+			"description": "Battery state for the device"
+		},
+		"lowPowerMode": {
+			"type": ["boolean", "null"],
+			"description": "A Boolean indicating whether Low Power Mode is enabled (iOS only)"
+		},
+		"availableStorage": {
+			"type": ["integer", "null"],
+			"minimum": 0,
+			"maximum": 9223372036854775807,
+			"description": "Bytes of storage remaining"
+		},
+		"totalStorage": {
+			"type": ["integer", "null"],
+			"minimum": 0,
+			"maximum": 9223372036854775807,
+			"description": "Total size of storage in bytes"
+		}
+	},
+	"required": ["osType", "osVersion", "deviceManufacturer", "deviceModel"],
+	"additionalProperties": false
+}


### PR DESCRIPTION
* Extended the mobile_context schema with new properties
* Added "null" types for existing optional properties
* Bumped mobile_context to version 1.0.2