### PR TITLE
Add version tag Metabase schema

### DIFF
--- a/schemas/com.metabase/tag/jsonschema/1-0-0
+++ b/schemas/com.metabase/tag/jsonschema/1-0-0
@@ -7,7 +7,6 @@
         "format": "jsonschema",
         "version": "1-0-0"
     },
-
     "type": "object",
     "properties": {
         "tag": {


### PR DESCRIPTION
At Metabase, we need to include `tag` with every snowplow event. This PR adds a schema for the tag.