### PR TITLE
Javascript Tracker HTML5 Media/YouTube schemas

### DIFF
--- a/schemas/com.snowplowanalytics.snowplow/media_player/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.snowplow/media_player/jsonschema/1-0-0
@@ -1,0 +1,76 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Common Context Schema for a media player event",
+  "self": {
+    "vendor": "com.snowplowanalytics.snowplow",
+    "name": "media_player",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "type": "object",
+  "properties": {
+    "currentTime": {
+      "type": "number",
+      "description": "The current playback time",
+      "minimum": 0,
+      "maximum": 9007199254740991
+    },
+    "duration": {
+      "type": [
+        "number",
+        "null"
+      ],
+      "description": "A double-precision floating-point value indicating the duration of the media in seconds",
+      "minimum": 0,
+      "maximum": 9007199254740991
+    },
+    "ended": {
+      "type": "boolean",
+      "description": "If playback of the media has ended"
+    },
+    "loop": {
+      "type": "boolean",
+      "description": "If the video should restart after ending"
+    },
+    "muted": {
+      "type": "boolean",
+      "description": "If the media element is muted"
+    },
+    "paused": {
+      "type": "boolean",
+      "description": "If the media element is paused"
+    },
+    "percentProgress": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "description": "The percent of the way through the media",
+      "minimum": 0,
+      "maximum": 100
+    },
+    "playbackRate": {
+      "type": "number",
+      "description": "Playback rate (1 is normal)",
+      "minimum": -9007199254740991,
+      "maximum": 9007199254740991
+    },
+    "volume": {
+      "type": "number",
+      "description": "Volume level",
+      "minimum": 0,
+      "maximum": 1
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "currentTime",
+    "duration",
+    "ended",
+    "loop",
+    "muted",
+    "paused",
+    "playbackRate",
+    "volume"
+  ]
+}

--- a/schemas/com.snowplowanalytics.snowplow/media_player_event/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.snowplow/media_player_event/jsonschema/1-0-0
@@ -1,0 +1,31 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Schema for a media event",
+  "self": {
+    "vendor": "com.snowplowanalytics.snowplow",
+    "name": "media_player_event",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "type": "object",
+  "properties": {
+    "type": {
+      "type": "string",
+      "description": "The event fired by the media player",
+      "maxLength": 255
+    },
+    "label": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "A custom identifier",
+      "maxLength": 4096
+    }
+  },
+  "required": [
+    "type"
+  ],
+  "additionalProperties": false
+}
+

--- a/schemas/org.whatwg/media_element/jsonschema/1-0-0
+++ b/schemas/org.whatwg/media_element/jsonschema/1-0-0
@@ -1,0 +1,274 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Context Schema for a media player event",
+  "self": {
+    "format": "jsonschema",
+    "name": "media_element",
+    "vendor": "org.whatwg",
+    "version": "1-0-0"
+  },
+  "type": "object",
+  "properties": {
+    "autoPlay": {
+      "type": "boolean",
+      "description": "If playback should automatically begin as soon as enough media is available to do so without interruption"
+    },
+    "buffered": {
+      "description": "An array of time ranges that have been buffered",
+      "items": {
+        "type": "object",
+        "description": "A time range object",
+        "properties": {
+          "start": {
+            "description": "The beginning of the time range",
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "number"
+          },
+          "end": {
+            "description": "The end of the time range",
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "number"
+          }
+        },
+        "additionalProperties": false
+      },
+      "type": "array"
+    },
+    "controls": {
+      "type": "boolean",
+      "description": "If the user agent should provide it's own set of controls"
+    },
+    "crossOrigin": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "CORS settings value of the media player",
+      "maxLength": 255
+    },
+    "currentSource": {
+      "type": "string",
+      "description": "The absolute URL of the media resource",
+      "maxLength": 65535
+    },
+    "defaultMuted": {
+      "type": "boolean",
+      "description": "If audio is muted by default"
+    },
+    "defaultPlaybackRate": {
+      "type": "number",
+      "description": "The default media playback rate of the player",
+      "minimum": -9007199254740991,
+      "maximum": 9007199254740991
+    },
+    "disableRemotePlayback": {
+      "type": [
+        "boolean",
+        "null"
+      ],
+      "description": "If the media element is allowed to have a remote playback UI"
+    },
+    "error": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "description": "An object of the latest error to occur, or null if no errors"
+    },
+    "fileExtension": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "The media file format",
+      "enum": [
+        "aac",
+        "aacp",
+        "caf",
+        "flac",
+        "mp3",
+        "mp4",
+        "ogg",
+        "wav",
+        "webm"
+      ],
+      "maxLength": 4,
+      "minLength": 3
+    },
+    "fullscreen": {
+      "type": [
+        "boolean",
+        "null"
+      ],
+      "description": "If the video element is fullscreen"
+    },
+    "mediaType": {
+      "type": "string",
+      "description": "If the media is a video element, or audio",
+      "enum": [
+        "AUDIO",
+        "VIDEO"
+      ],
+      "maxLength": 5
+    },
+    "networkState": {
+      "description": "The current state of the fetching of media over the network",
+      "enum": [
+        "NETWORK_EMPTY",
+        "NETWORK_IDLE",
+        "NETWORK_LOADING",
+        "NETWORK_NO_SOURCE"
+      ],
+      "type": "string"
+    },
+    "pictureInPicture": {
+      "description": "If the video element is showing Picture-In-Picture",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "played": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "description": "An array of time ranges played",
+      "items": {
+        "type": "object",
+        "description": "A time range",
+        "properties": {
+          "start": {
+            "type": "number",
+            "description": "The beginning of the time range",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991
+          },
+          "end": {
+            "type": "number",
+            "description": "The end of the time range",
+            "minimum": -9007199254740991,
+            "maximum": 9007199254740991
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "htmlId": {
+      "type": "string",
+      "description": "The HTML id of the element",
+      "maxLength": 65535
+    },
+    "preload": {
+      "type": "string",
+      "description": "The 'preload' HTML attribute of the media",
+      "maxLength": 65535
+    },
+    "readyState": {
+      "type": "string",
+      "description": "The readiness of the media",
+      "enum": [
+        "HAVE_NOTHING",
+        "HAVE_METADATA",
+        "HAVE_CURRENT_DATA",
+        "HAVE_FUTURE_DATA",
+        "HAVE_ENOUGH_DATA"
+      ]
+    },
+    "seekable": {
+      "type": "array",
+      "description": "Seekable time range(s)",
+      "items": {
+        "type": "object",
+        "description": "A time range",
+        "properties": {
+          "end": {
+            "description": "The end of the time range",
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "number"
+          },
+          "start": {
+            "description": "The beginning of the time range",
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "number"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "seeking": {
+      "type": "boolean",
+      "description": "If the media is in the process of seeking to a new position"
+    },
+    "src": {
+      "type": "string",
+      "description": "The 'src' HTML attribute of the media element",
+      "maxLength": 65535
+    },
+    "textTracks": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "description": "An array of TextTrack objects on the media element",
+      "items": {
+        "type": "object",
+        "description": "A Text Track object",
+        "properties": {
+          "kind": {
+            "type": "string",
+            "description": "The kind of text track this object represents",
+            "enum": [
+              "subtitles",
+              "captions",
+              "descriptions",
+              "chapters", 
+              "metadata"
+            ]
+          },
+          "label": {
+            "type": "string",
+            "description": "The given label for the text track",
+            "maxLength": 65535
+          },
+          "language": {
+            "type": "string",
+            "description": "The locale of the text track, matching BCP-47 (https://www.rfc-editor.org/info/bcp47)",
+            "maxLength": 35
+          },
+          "mode": {
+            "type": "string",
+            "description": "The mode the text track is in",
+            "enum": [
+              "disabled",
+              "hidden",
+              "showing"
+            ]
+          }
+        }
+      }
+    }
+  },
+  "required": [
+    "autoPlay",
+    "buffered",
+    "controls",
+    "currentSource",
+    "defaultMuted",
+    "defaultPlaybackRate",
+    "error",
+    "htmlId",
+    "mediaType",
+    "networkState",
+    "preload",
+    "readyState",
+    "seekable",
+    "seeking",
+    "src"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/org.whatwg/video_element/jsonschema/1-0-0
+++ b/schemas/org.whatwg/video_element/jsonschema/1-0-0
@@ -1,0 +1,52 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Context Schema for a video player event",
+  "self": {
+    "vendor": "org.whatwg",
+    "name": "video_element",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "type": "object",
+  "properties": {
+    "autoPictureInPicture": {
+      "type": [
+        "boolean",
+        "null"
+      ],
+      "description": "A boolean value that is true if the video should enter or leave picture-in-picture mode automatically when changing tab and/or application"
+    },
+    "disablePictureInPicture": {
+      "type": [
+        "boolean",
+        "null"
+      ],
+      "description": "The disablePictureInPicture property will hint the user agent to not suggest the picture-in-picture to users or to request it automatically"
+    },
+    "poster": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "'poster' HTML attribute, which specifies an image to show while no video data is available",
+      "maxLength": 65535
+    },
+    "videoHeight": {
+      "type": "integer",
+      "description": "A value indicating the intrinsic height of the resource in CSS pixels, or 0 if no media is available yet",
+      "minimum": 0,
+      "maximum": 65535
+    },
+    "videoWidth": {
+      "type": "integer",
+      "description": "A value indicating the intrinsic width of the resource in CSS pixels, or 0 if no media is available yet",
+      "minimum": 0,
+      "maximum": 65535
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "videoHeight",
+    "videoWidth"
+  ]
+}

--- a/schemas/org.youtube/youtube/jsonschema/1-0-0
+++ b/schemas/org.youtube/youtube/jsonschema/1-0-0
@@ -1,0 +1,143 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Context Schema for a youtube player event",
+  "self": {
+    "vendor": "org.youtube",
+    "name": "youtube",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "type": "object",
+  "properties": {
+    "avaliablePlaybackRates": {
+      "type": "array",
+      "description": "An array of playback rates in which the current video is available",
+      "items": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 9007199254740991
+      }
+    },
+    "cued": {
+      "type": "boolean",
+      "description": "If the video is cued"
+    },
+    "playerId": {
+      "type": "string",
+      "description": "The HTML id of the video element",
+      "maxLength": 65535
+    },
+    "autoPlay": {
+      "type": "boolean",
+      "description": "This specifies whether the initial video will automatically start to play when the player loads."
+    },
+    "buffering": {
+      "type": "boolean",
+      "description": "If the player is buffering"
+    },
+    "controls": {
+      "type": "boolean",
+      "description": "Whether the video player controls are displayed"
+    },
+    "error": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "An string of the latest error to occur, or null if no errors",
+      "enum": [
+        "INVALID_PARAMETER",
+        "HTML5_PLAYER_ERROR",
+        "NOT_FOUND",
+        "EMBED_DISALLOWED"
+      ]
+    },
+    "loaded": {
+      "type": "number",
+      "description": "The percentage of the video that the player shows as buffered",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "origin": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "The origin domain of the embed",
+      "maxLength": 65535
+    },
+    "playlist": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "description": "An array of the video IDs in the playlist as they are currently ordered."
+    },
+    "playlistIndex": {
+      "type": [
+        "number",
+        "null"
+      ],
+      "description": "The index of the playlist video that is currently playing",
+      "minimum": 0,
+      "maximum": 65535
+    },
+    "unstarted": {
+      "type": "boolean",
+      "description": "If the player hasn't started"
+    },
+    "url": {
+      "type": "string",
+      "description": "The YouTube embed URL of the media resource",
+      "maxLength": 65535
+    },
+    "fov": {
+      "type": [
+        "number",
+        "null"
+      ],
+      "description": "The field-of-view of the view in degrees, as measured along the longer edge of the viewport",
+      "minimum": 30,
+      "maximum": 120
+    },
+    "roll": {
+      "type": [
+        "number",
+        "null"
+      ],
+      "description": "The clockwise or counterclockwise rotational angle of the view in degrees",
+      "minimum": -180,
+      "maximum": 180
+    },
+    "pitch": {
+      "type": [
+        "number",
+        "null"
+      ],
+      "description": "The vertical angle of the view in degrees",
+      "minimum": -90,
+      "maximum": 90
+    },
+    "yaw": {
+      "type": [
+        "number",
+        "null"
+      ],
+      "description": "The horizontal angle of the view in degrees",
+      "minimum": 0,
+      "maximum": 360
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "avaliablePlaybackRates",
+    "autoPlay",
+    "buffering",
+    "controls",
+    "cued",
+    "loaded",
+    "playerId",
+    "unstarted",
+    "url"
+  ]
+}


### PR DESCRIPTION
Schemas included:

- Event context (The event emitted and the label provided by the user):
https://github.com/snowplow/iglu-central/issues/1177

- Common Snowplow media context (A set of entities that are common between media events across platforms):
https://github.com/snowplow/iglu-central/issues/1176

- HTMLMediaElement context (Entities related to the HTML5 Media Element, adapted from  the [whatwg spec](https://html.spec.whatwg.org/multipage/media.html#htmlmediaelement)):
https://github.com/snowplow/iglu-central/issues/1178

- HTMLVideoElement context (Entities related to the HTML5 Media Element, adapted from  the [whatwg spec](https://html.spec.whatwg.org/multipage/media.html#the-video-element)):
https://github.com/snowplow/iglu-central/issues/1179

- YouTube specific context (Entities that are specific to YouTube, adapted from the [YouTube IFrame API Spec](https://developers.google.com/youtube/iframe_api_reference)):
https://github.com/snowplow/iglu-central/issues/1180
