### PR TITLE
Patch com.snowplowanalytics.snowplow/mobile_context/jsonschema/1-0-2 (close #1197)

### DIFF
--- a/schemas/com.snowplowanalytics.snowplow/mobile_context/jsonschema/1-0-2
+++ b/schemas/com.snowplowanalytics.snowplow/mobile_context/jsonschema/1-0-2
@@ -58,7 +58,7 @@
 		"appAvailableMemory": {
 			"type": ["integer", "null"],
 			"minimum": 0,
-			"maximum": 4294967295,
+			"maximum": 9223372036854775807,
 			"description": "Amount of memory in bytes available to the current app (iOS only)"
 		},
 		"batteryLevel": {


### PR DESCRIPTION
Patches `mobile_context` schema to increase the max limit for the `appAvailableMemory` property. It was set too low and some devices (new iPad Pros) already cross the 4GB threshold. Increasing it to match max values for other memory properties.

Issue #1197