### PR TITLE
R131

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,9 @@
-Release 131 (2021-12-21)
+Release 131 (2022-01-24)
 ------------------------
 Add com.roku/device_info/jsonschema/1-0-0 (#1190)
 Add com.roku/video/jsonschema/1-0-0 (#1189)
 Add com.snowplowanalytics.monitoring.batch/load_succeeded/jsonschema/2-0-0 (#1195)
+Patch com.snowplowanalytics.snowplow/mobile_context/jsonschema/1-0-2 (#1197)
 
 Release 130 (2021-12-01)
 ------------------------

--- a/schemas/com.snowplowanalytics.snowplow/mobile_context/jsonschema/1-0-2
+++ b/schemas/com.snowplowanalytics.snowplow/mobile_context/jsonschema/1-0-2
@@ -58,7 +58,7 @@
 		"appAvailableMemory": {
 			"type": ["integer", "null"],
 			"minimum": 0,
-			"maximum": 4294967295,
+			"maximum": 9223372036854775807,
 			"description": "Amount of memory in bytes available to the current app (iOS only)"
 		},
 		"batteryLevel": {


### PR DESCRIPTION
This updated release patches `mobile_context` schema to increase the max limit for the appAvailableMemory property. It was set too low and some devices (new iPad Pros) already cross the 4GB threshold. Increasing it to match max values for other memory properties. Hoping that we can go for a patch release instead of new version of the schema to avoid having to publish a new version of the mobile trackers and fix issues for users implementing the current tracker version.