### PR TITLE
Add com.iterable/system_webhook/jsonschema/1-0-0 (close #1204)

### DIFF
--- a/schemas/com.iterable/system_webhook/jsonschema/1-0-0
+++ b/schemas/com.iterable/system_webhook/jsonschema/1-0-0
@@ -1,0 +1,695 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Schema for an event from Iterable system webhooks",
+  "self": {
+    "vendor": "com.iterable",
+    "name": "system_webhook",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "type": "object",
+  "properties": {
+    "email": {
+      "type": "string",
+      "description": "The email address associated with the event",
+      "maxLength": 320,
+      "format": "email"
+    },
+    "eventName": {
+      "type": "string",
+      "description": "The name of the event for which a webhook has been triggered",
+      "maxLength": 4096
+    },
+    "dataFields": {
+      "type": "object",
+      "properties": {
+        "appAlreadyRunning": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "description": "Whether or not the app was already running when the push notification arrived."
+        },
+        "badge": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Badge to set for push notification",
+          "maxLength": 4096
+        },
+        "bounceMessage": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "E-mail bounce message.",
+          "maxLength": 4096
+        },
+        "browserToken": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Token provided by Firebase Messaging javascript API.",
+          "maxLength": 4096
+        },
+        "campaignId": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0,
+          "maximum": 9223372036854775807,
+          "description": "Reference to the campaign from which the event originated (e.g., 74768)"
+        },
+        "campaignName": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Campaign name",
+          "maxLength": 4096
+        },
+        "canonicalUrlId": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Reference to the URL associated with the event (e.g., '3145668988')",
+          "maxLength": 4096
+        },
+        "catalogCollectionCount": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0,
+          "maximum": 2147483647,
+          "description": "The number of times a catalog collection was referenced in the message."
+        },
+        "catalogLookupCount": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0,
+          "maximum": 2147483647,
+          "description": "The number of times a catalog was referenced in the message."
+        },
+        "channelId": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0,
+          "maximum": 9223372036854775807,
+          "description": "Unique identifier of the channel (e.g., 2203)"
+        },
+        "channelIds": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "minimum": 0,
+            "maximum": 9223372036854775807
+          },
+          "description": "Channel IDs"
+        },
+        "city": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "City (e.g., 'San Jose')",
+          "maxLength": 4096
+        },
+        "contentAvailable": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "description": "Is content available"
+        },
+        "contentId": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0,
+          "maximum": 9223372036854775807,
+          "description": "Reference to the content the event is associated with (e.g., 3681)"
+        },
+        "country": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Country (e.g., 'United States')",
+          "maxLength": 4096
+        },
+        "createdAt": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Creation timestamp (e.g., '2017-05-15 23:59:47 +00:00')",
+          "maxLength": 255
+        },
+        "deeplink": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "android": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "maxLength": 4096
+            },
+            "ios": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "maxLength": 4096
+            }
+          },
+          "additionalProperties": true,
+          "description": "Deep Link. A mapping that accepts two optional properties: 'ios' & 'android' and their respective deep link values."
+        },
+        "device": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Device application name (e.g., 'Gmail')",
+          "maxLength": 4096
+        },
+        "email": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Reference to the unique user the event was applied to.",
+          "maxLength": 320,
+          "format": "email"
+        },
+        "emailId": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Reference to the email associated with the event (e.g., 'c59667:t93849:docs@iterable.com')",
+          "maxLength": 4096
+        },
+        "emailIds": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string",
+            "maxLength": 4096,
+            "description": "Reference to email"
+          },
+          "description": "References to emails associated with the event"
+        },
+        "emailListIds": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "minimum": 0,
+            "maximum": 9223372036854775807
+          },
+          "description": "Lists that a user is subscribed to"
+        },
+        "emailSubject": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Subject of the email associated with the event",
+          "maxLength": 998
+        },
+        "experimentId": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0,
+          "maximum": 9223372036854775807,
+          "description": "Reference to the experiment used if the event is an experiment"
+        },
+        "expiresAt": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Expires at (e.g., '2019-08-08 22:37:40 +00:00')",
+          "maxLength": 255
+        },
+        "firstName": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "First name",
+          "maxLength": 4096
+        },
+        "fromPhoneNumber": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Phone number which the event is from (e.g., '+16503926753')",
+          "maxLength": 255
+        },
+        "fromPhoneNumberId": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0,
+          "maximum": 9223372036854775807,
+          "description": "Reference to the phone number which the event is from (e.g., 258)"
+        },
+        "fromSMSSenderId": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0,
+          "maximum": 9223372036854775807,
+          "description": "Reference to the SMS sender which the event is from (e.g., 258)"
+        },
+        "imageUrl": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Image URL of the event.",
+          "maxLength": 4096
+        },
+        "inAppBody": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "In app body HTML",
+          "maxLength": 32700
+        },
+        "ip": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "IP address (e.g., '192.168.0.1')",
+          "maxLength": 128
+        },
+        "isGhostPush": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "description": "Boolean indicating if the event is a result of a ghost push"
+        },
+        "labels": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "description": "Labels",
+          "items": {
+            "type": "string",
+            "description": "Label",
+            "maxLength": 4096
+          }
+        },
+        "lastName": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Last name",
+          "maxLength": 4096
+        },
+        "linkId": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Reference to the link associated with the event (e.g., '3145668988')",
+          "maxLength": 4096
+        },
+        "linkUrl": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "URL of the link associated with the event",
+          "maxLength": 4096
+        },
+        "locale": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Locale associated with the event",
+          "maxLength": 4096
+        },
+        "messageBusId": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Message bus ID",
+          "maxLength": 4096
+        },
+        "messageContext": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "saveToInbox": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "description": "Save to inbox"
+            },
+            "trigger": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "Trigger (e.g., 'immediate')",
+              "maxLength": 4096
+            }
+          },
+          "description": "An object containing various fields that describe the message associated with the event",
+          "additionalProperties": true
+        },
+        "messageId": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Reference to the message the event is associated with (e.g., 'vA16d48VVi4LQ5hMuZuquKzL0BXTdQJJUMJRjKnL1')",
+          "maxLength": 4096
+        },
+        "messageTypeId": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0,
+          "maximum": 2147483647,
+          "description": "Reference to the type of message the event is associated with (e.g., 14381)"
+        },
+        "messageTypeIds": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 2147483647
+          },
+          "description": "Message type IDs"
+        },
+        "platformEndpoint": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "The specific platform endpoint of the event",
+          "maxLength": 4096
+        },
+        "productRecommendationCount": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0,
+          "maximum": 2147483647,
+          "description": "Product recommendation count."
+        },
+        "profileUpdatedAt": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "2020-03-20 23:11:58 +00:00",
+          "maxLength": 255
+        },
+        "proxySource": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Proxy source (e.g., 'Apple')",
+          "maxLength": 4096
+        },
+        "pushMessage": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Push message text",
+          "maxLength": 4096
+        },
+        "reason": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Reason (e.g., 'DuplicateMarketingMessage')",
+          "maxLength": 4096
+        },
+        "recipientState": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "The state of the recipient upon receiving the event (e.g., 'HardBounce')",
+          "maxLength": 4096
+        },
+        "region": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Region of the event (e.g., 'CA')",
+          "maxLength": 4096
+        },
+        "signupSource": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Sign-up source (e.g., 'UpdateSubscriptionsAPI')",
+          "maxLength": 4096
+        },
+        "smsMessage": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "SMS message text",
+          "maxLength": 4096
+        },
+        "smsProviderResponse": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "status": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "description": "Status of the SMS provider response from the event (e.g., 404)"
+            },
+            "message": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "SMS provider response message from the event (e.g., 'The requested resource was not found'",
+              "maxLength": 4096
+            },
+            "code": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "maximum": 2147483647,
+              "minimum": -2147483648,
+              "description": "SMS provider response code from the event (e.g., 20404)"
+            },
+            "more_info": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "SMS provider response addition info from the event (e.g, a URL)",
+              "maxLength": 4096
+            }
+          },
+          "description": "SMS provider response",
+          "additionalProperties": true
+        },
+        "sound": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Sound",
+          "maxLength": 4096
+        },
+        "status": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Status (e.g., '5.1.2')",
+          "maxLength": 4096
+        },
+        "templateId": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0,
+          "maximum": 9223372036854775807,
+          "description": "The ID of the Iterable template (e.g., 167484)"
+        },
+        "templateName": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Template name",
+          "maxLength": 4096
+        },
+        "toPhoneNumber": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "To phone number associated with the event (e.g., '+16503926753')",
+          "maxLength": 255
+        },
+        "unsubSource": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Source of the unsubscribe event (e.g., 'EmailLink')",
+          "maxLength": 4096
+        },
+        "url": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "URL associated with the event",
+          "maxLength": 4096
+        },
+        "userAgent": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "User agent associated with the event",
+          "maxLength": 4096
+        },
+        "userAgentDevice": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "The device of the user agent (e.g., 'Mac')",
+          "maxLength": 4096
+        },
+        "webPushBody": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Web push notification body",
+          "maxLength": 4096
+        },
+        "webPushClickAction": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Web push notification click action",
+          "maxLength": 4096
+        },
+        "webPushIcon": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Web push notification icon",
+          "maxLength": 4096
+        },
+        "webPushMessage": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Web push notification message",
+          "maxLength": 4096
+        },
+        "workflowId": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0,
+          "maximum": 9223372036854775807,
+          "description": "Reference to the workflow which the event originated (e.g., 53505)"
+        },
+        "workflowName": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Name of the workflow which the event originated",
+          "maxLength": 4096
+        }
+      },
+      "description": "Information stored with the event.",
+      "additionalProperties": true
+    }
+  },
+  "minProperties": 3,
+  "required": [
+    "email",
+    "eventName",
+    "dataFields"
+  ],
+  "additionalProperties": true
+}


### PR DESCRIPTION
Issue #1024 

The schema was produced based on example payloads in the [Iterable system webhook documentation](https://support.iterable.com/hc/en-us/articles/208013936-System-Webhooks-) and events that I was able to trigger manually in a test account on Iterable. Unfortunately, there is no documentation that would list all the properties and their types so I can't be 100% sure about the schema. We also didn't get a response from Iterable after we asked them to confirm the properties and types.

I decided to leave out the `transactionalData` property that I saw conflicting examples for and couldn't find out it's type. We may add it in a future version of the schema when we are more certain about it. Other properties I am fairly certain about and would be surprised if they turned out to have a different type (although I can't rule that out).

I created a testing repository where I collected the examples of the events and created a script that sends the events to a Micro instance to validate that the schema supports them: https://github.com/snowplow-incubator/snowplow-iterable-webhook-schema