### PR TITLE
Add com.snowplowanalytics.snowplow/web_page/jsonschema/1-0-1 (closes #1222)

### DIFF
--- a/schemas/com.snowplowanalytics.snowplow/web_page/jsonschema/1-0-1
+++ b/schemas/com.snowplowanalytics.snowplow/web_page/jsonschema/1-0-1
@@ -1,0 +1,25 @@
+{
+    "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+    "description": "Schema for a web page context",
+    "self": {
+        "vendor": "com.snowplowanalytics.snowplow",
+        "name": "web_page",
+        "format": "jsonschema",
+        "version": "1-0-1"
+    },
+    "type": "object",
+    "properties": {
+        "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "An identifier for the current page view."
+        },
+        "tabId": {
+            "type": ["string", "null"],
+            "format": "uuid",
+            "description": "An identifier for the client browser tab the event is sent from."
+        }
+    },
+    "required": ["id"],
+    "additionalProperties": false
+}


### PR DESCRIPTION
Closes #1222 

- Both `id` and `tabId` are generated using the [uuid](https://www.npmjs.com/package/uuid) pacakge which produces valid UUIDs. 
- `tabId` is the identifier of the current tab the event was sent from. More info on the [JS repository](https://github.com/snowplow/snowplow-javascript-tracker/pull/1088). 