### PR TITLE
Add com.android.installreferrer.api/referrer_details/jsonschema/1-0-0 (close #1254)

### DIFF
--- a/schemas/com.android.installreferrer.api/referrer_details/jsonschema/1-0-0
+++ b/schemas/com.android.installreferrer.api/referrer_details/jsonschema/1-0-0
@@ -1,0 +1,36 @@
+{
+	"$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+	"description": "Represents an install referrer details for Android apps installed from the Play Store (see https://developer.android.com/reference/com/android/installreferrer/api/ReferrerDetails)",
+	"self": {
+		"vendor": "com.android.installreferrer.api",
+		"name": "referrer_details",
+		"format": "jsonschema",
+		"version": "1-0-0"
+	},
+	"type": "object",
+	"properties": {
+		"installReferrer": {
+			"type": ["string", "null"],
+			"maxLength": 4096,
+			"description": "The referrer URL of the installed package"
+		},
+		"referrerClickTimestampSeconds": {
+			"type": "integer",
+			"minimum": 0,
+			"maximum": 9223372036854775807,
+			"description": "The timestamp in seconds when referrer click happens"
+		},
+		"installBeginTimestampSeconds": {
+			"type": "integer",
+			"minimum": 0,
+			"maximum": 9223372036854775807,
+			"description": "The timestamp in seconds when installation begins"
+		},
+		"googlePlayInstantParam": {
+			"type": "boolean",
+			"description": "Boolean indicating if the user has interacted with the app's instant experience in the past 7 days"
+		}
+	},
+	"required": ["referrerClickTimestampSeconds", "installBeginTimestampSeconds", "googlePlayInstantParam"],
+	"additionalProperties": false
+}


### PR DESCRIPTION
Issue #1254

Add schema for the install referrer information provided by the [Google Play Install Referrer Library](https://developer.android.com/google/play/installreferrer/library) for Android apps. The library enables mobile app install attribution by surfacing the referrer URL which led to the app being installed from the Play Store. This URL may contain `umd` or other parameters to attribute the install to a campaign.

Unfortunately, this is an Android-only feature, there is no equivalent on iOS.