### PR TITLE
Release R140

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+Release 140 (2022-02-02)
+------------------------
+Add com.snowplowanalytics.snowplow/browser_context/jsonschema/1-0-0 (#1249)
+Add com.android.installreferrer.api/referrer_details/jsonschema/1-0-0 (#1254)
+Add com.snowplowanalytics.snowplow.ecommerce/promotion/jsonschema/1-0-0 (#1263)
+Add com.snowplowanalytics.snowplow.ecommerce/snowplow_ecommerce_action/jsonschema/1-0-1 (#1261)
+
 Release 139 (2022-01-09)
 ------------------------
 Add com.snowplowanalytics.snowplow.storage/shredding_complete/jsonschema/2-0-1 (close #1247)

--- a/schemas/com.android.installreferrer.api/referrer_details/jsonschema/1-0-0
+++ b/schemas/com.android.installreferrer.api/referrer_details/jsonschema/1-0-0
@@ -1,0 +1,34 @@
+{
+	"$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+	"description": "Represents an install referrer details for Android apps installed from the Play Store (see https://developer.android.com/reference/com/android/installreferrer/api/ReferrerDetails)",
+	"self": {
+		"vendor": "com.android.installreferrer.api",
+		"name": "referrer_details",
+		"format": "jsonschema",
+		"version": "1-0-0"
+	},
+	"type": "object",
+	"properties": {
+		"installReferrer": {
+			"type": ["string", "null"],
+			"maxLength": 4096,
+			"description": "The referrer URL of the installed package"
+		},
+		"referrerClickTimestamp": {
+			"type": ["string", "null"],
+			"format": "date-time",
+			"description": "The timestamp when referrer click happens"
+		},
+		"installBeginTimestamp": {
+			"type": ["string", "null"],
+			"format": "date-time",
+			"description": "The timestamp when installation begins"
+		},
+		"googlePlayInstantParam": {
+			"type": "boolean",
+			"description": "Boolean indicating if the user has interacted with the app's instant experience in the past 7 days"
+		}
+	},
+	"required": ["googlePlayInstantParam"],
+	"additionalProperties": false
+}

--- a/schemas/com.snowplowanalytics.snowplow.ecommerce/promotion/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.snowplow.ecommerce/promotion/jsonschema/1-0-0
@@ -1,0 +1,62 @@
+{
+    "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+    "description": "Schema for a promotion entity in Ecommerce",
+    "self": {
+        "vendor": "com.snowplowanalytics.snowplow.ecommerce",
+        "name": "promotion",
+        "format": "jsonschema",
+        "version": "1-0-0"
+    },
+    "type": "object",
+    "properties": {
+        "id": {
+            "description" : "The ID of the promotion.",
+            "type": "string",
+            "maxLength": 4096
+        },
+        "name": {
+            "description" : "The name of the promotion.",
+            "type": [ "string", "null" ],
+            "maxLength": 256
+        },
+        "product_ids" : {
+            "description" : "Array of SKUs or product IDs showcased in the promotion.",
+            "type" : [ "array", "null" ],
+            "items" : {
+                "type" : "string",
+                "maxLength": 4096
+            }
+        },
+        "position": {
+            "description" : "The position the promotion was presented in a list of promotions E.g. banner, slider.",
+            "type" : [
+                "integer",
+                "null"
+            ],
+            "minimum": 0,
+            "maximum": 9999999
+        },
+        "creative_id": {
+            "description" : "Identifier/Name/Url for the creative presented on the promotion.",
+            "type" : [
+                "string",
+                "null"
+            ],
+            "maxLength": 4096
+        },
+        "type": {
+            "description": "Type of the promotion delivery mechanism. E.g. popup, banner, intra-content",
+            "type": [ "string", "null" ],
+            "maxLength": 256
+        },
+        "slot": {
+            "description": "The website slot in which the promotional content was added to. E.g. Identifier for slot sidebar-1, intra-content-2",
+            "type": [ "string", "null" ],
+            "maxLength": 256
+        }
+    },
+    "required": [
+        "id"
+    ],
+    "additionalProperties": false
+}

--- a/schemas/com.snowplowanalytics.snowplow.ecommerce/snowplow_ecommerce_action/jsonschema/1-0-1
+++ b/schemas/com.snowplowanalytics.snowplow.ecommerce/snowplow_ecommerce_action/jsonschema/1-0-1
@@ -1,0 +1,40 @@
+{
+    "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+    "description": "Schema for an Ecommerce action",
+    "self": {
+        "vendor": "com.snowplowanalytics.snowplow.ecommerce",
+        "name": "snowplow_ecommerce_action",
+        "format": "jsonschema",
+        "version": "1-0-1"
+    },
+    "type": "object",
+    "properties": {
+        "type": {
+            "description": "Standard ecommerce actions.",
+            "enum": [
+                "add_to_cart",
+                "remove_from_cart",
+                "product_view",
+                "list_click",
+                "list_view",
+                "promo_click",
+                "promo_view",
+                "checkout_step",
+                "transaction",
+                "refund"
+            ]
+        },
+        "name": {
+            "description": "The name of the list presented to the user E.g. product list, search results, shop the look, frequently bought with.",
+            "type": [
+                "string",
+                "null"
+            ],
+            "maxLength": 128
+        }
+    },
+    "required": [
+        "type"
+    ],
+    "additionalProperties": false
+}

--- a/schemas/com.snowplowanalytics.snowplow/browser_context/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.snowplow/browser_context/jsonschema/1-0-0
@@ -1,0 +1,81 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Schema for browser contexts",
+  "self": {
+    "vendor": "com.snowplowanalytics.snowplow",
+    "name": "browser_context",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "type": "object",
+  "properties": {
+    "viewport": {
+      "type": "string",
+      "maxLength": 20,
+      "description": "Viewport dimensions of the browser. Arrives in the form of WidthxHeight e.g. 1200x900."
+    },
+    "documentSize": {
+      "type": "string",
+      "maxLength": 20,
+      "description": "Document dimensions. Arrives in the form of WidthxHeight e.g. 1200x900"
+    },
+    "resolution": {
+      "type": "string",
+      "maxLength": 20,
+      "description": "Device native resolution. Arrives in the form of WidthxHeight e.g. 1200x900"
+    },
+    "colorDepth": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 1000,
+      "description": "The number of bits allocated to colors for a pixel in the output device, excluding the alpha channel."
+    },
+    "devicePixelRatio": {
+      "type": ["number", "null"],
+      "minimum": 0,
+      "maximum": 1000,
+      "description": "Ratio of the resolution in physical pixels to the resolution in CSS pixels for the current display device."
+    },
+    "cookiesEnabled": {
+      "type": "boolean",
+      "description": "Indicates whether cookies are enabled or not. More info and caveats at https://developer.mozilla.org/en-US/docs/Web/API/Navigator/cookieEnabled."
+    },
+    "online": {
+      "type": "boolean",
+      "description": "Returns the online status of the browser. Important caveats are described in https://developer.mozilla.org/en-US/docs/Web/API/Navigator/onLine."
+    },
+    "browserLanguage": {
+      "type": ["string", "null"],
+      "maxLength": 20,
+      "description": "The preferred language of the user, usually the language of the browser UI. RFC 5646 https://datatracker.ietf.org/doc/html/rfc5646."
+    },
+    "documentLanguage": {
+      "type": ["string", "null"],
+      "maxLength": 20,
+      "description": "The language of the HTML document. RFC 5646 https://datatracker.ietf.org/doc/html/rfc5646."
+    },
+    "webdriver": {
+      "type": ["boolean", "null"],
+      "description": "Indicates whether the user agent is controlled by automation."
+    },
+    "deviceMemory": {
+      "type": ["integer", "null"],
+      "minimum": 0,
+      "maximum": 1000,
+      "description": "Approximate amount of device memory in gigabytes."
+    },
+    "hardwareConcurrency": {
+      "type": ["integer", "null"],
+      "minimum": 0,
+      "maximum": 1000,
+      "description": "Number of logical processors available to run threads on the user's computer."
+    },
+    "tabId": {
+      "type": ["string", "null"],
+      "format": "uuid",
+      "description": "An identifier for the client browser tab the event is sent from."
+    }
+  },
+  "required": ["viewport", "documentSize", "cookiesEnabled", "online", "colorDepth", "resolution"],
+  "additionalProperties": false
+}


### PR DESCRIPTION
This PR was done with @igneel64 and adds a new schema for `browser_context` with information tracked by the JS tracker that used to be stored in canonical event properties and also some new info (e.g., `tabId`). It also adds a new schema for `install_referrer` to be tracked on Android.

Change | Issue | Issue PR
-- | -- | --
Add com.snowplowanalytics.snowplow/browser_context/jsonschema/1-0-0 | #1249 | #1250
Add com.android.installreferrer.api/referrer_details/jsonschema/1-0-0 | #1254 | #1255