### PR TITLE
Add media player entity schemas

### DIFF
--- a/schemas/com.snowplowanalytics.snowplow.media/ad/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.snowplow.media/ad/jsonschema/1-0-0
@@ -1,0 +1,63 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Schema for a context entity with information about the currently played ad",
+  "self": {
+    "vendor": "com.snowplowanalytics.snowplow.media",
+    "name": "ad",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "type": "object",
+  "properties": {
+    "name": {
+      "description": "Friendly name of the ad.",
+      "type": [
+        "null",
+        "string"
+      ],
+      "maxLength": 4096
+    },
+    "adId": {
+      "type": "string",
+      "maxLength": 256,
+      "description": "Unique identifier for the ad."
+    },
+    "creativeId": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 4096,
+      "description": "The ID of the ad creative."
+    },
+    "podPosition": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "description": "The position of the ad within the ad break, starting with 1.",
+      "minimum": 1,
+      "maximum": 65535
+    },
+    "duration": {
+      "type": [
+        "number",
+        "null"
+      ],
+      "description": "Length of the video ad in seconds.",
+      "minimum": 0,
+      "maximum": 2147483647
+    },
+    "skippable": {
+      "type": [
+        "boolean",
+        "null"
+      ],
+      "description": "Indicating whether skip controls are made available to the end user."
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "adId"
+  ]
+}

--- a/schemas/com.snowplowanalytics.snowplow.media/ad_break/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.snowplow.media/ad_break/jsonschema/1-0-0
@@ -1,0 +1,59 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Schema for a context entity, shared with all ad events belonging to the ad break.",
+  "self": {
+    "vendor": "com.snowplowanalytics.snowplow.media",
+    "name": "ad_break",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "type": "object",
+  "properties": {
+    "name": {
+      "description": "Ad break name (e.g., pre-roll, mid-roll, and post-roll).",
+      "type": [
+        "null",
+        "string"
+      ],
+      "maxLength": 4096
+    },
+    "breakId": {
+      "type": "string",
+      "maxLength": 256,
+      "description": "An identifier for the ad break."
+    },
+    "startTime": {
+      "type": "number",
+      "description": "Playback time in seconds at the start of the ad break.",
+      "minimum": 0,
+      "maximum": 2147483647
+    },
+    "breakType": {
+      "description": "Type of ads within the break: linear (take full control of the video for a period of time), nonlinear (run concurrently to the video), companion (accompany the video but placed outside the player).",
+      "enum": [
+        "linear",
+        "nonlinear",
+        "companion",
+        null
+      ],
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "podSize": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "description": "The number of ads to be played within the ad break.",
+      "minimum": 0,
+      "maximum": 65535
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "breakId",
+    "startTime"
+  ]
+}

--- a/schemas/com.snowplowanalytics.snowplow.media/player/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.snowplow.media/player/jsonschema/1-0-0
@@ -1,0 +1,131 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Schema for a context entity for media events that describes the media player and playback state",
+  "self": {
+    "vendor": "com.snowplowanalytics.snowplow.media",
+    "name": "player",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "type": "object",
+  "properties": {
+    "currentTime": {
+      "type": "number",
+      "description": "The current playback time position within the media in seconds.",
+      "minimum": 0,
+      "maximum": 2147483647
+    },
+    "duration": {
+      "type": [
+        "number",
+        "null"
+      ],
+      "description": "A floating-point value indicating the duration of the media in seconds.",
+      "minimum": 0,
+      "maximum": 2147483647
+    },
+    "ended": {
+      "type": "boolean",
+      "description": "Whether playback of the media has ended."
+    },
+    "fullscreen": {
+      "type": [
+        "boolean",
+        "null"
+      ],
+      "description": "Whether the video element is fullscreen."
+    },
+    "livestream": {
+      "type": [
+        "boolean",
+        "null"
+      ],
+      "description": "Whether the media is a live stream."
+    },
+    "label": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "Human readable name given to tracked media content.",
+      "maxLength": 4096
+    },
+    "loop": {
+      "type": [
+        "boolean",
+        "null"
+      ],
+      "description": "Whether the video should restart after ending."
+    },
+    "mediaType": {
+      "description": "Type of media content.",
+      "enum": [
+        "video",
+        "audio",
+        null
+      ],
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "muted": {
+      "type": [
+        "boolean",
+        "null"
+      ],
+      "description": "Whether the media element is muted."
+    },
+    "paused": {
+      "type": "boolean",
+      "description": "Whether the media element is paused"
+    },
+    "pictureInPicture": {
+      "type": [
+        "boolean",
+        "null"
+      ],
+      "description": "Whether the video element is showing picture-in-picture."
+    },
+    "playbackRate": {
+      "type": [
+        "number",
+        "null"
+      ],
+      "description": "Playback rate (1 is normal).",
+      "minimum": 0,
+      "maximum": 16
+    },
+    "playerType": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "Type of the media player (e.g., com.youtube-youtube, com.vimeo-vimeo, org.whatwg-media_element).",
+      "maxLength": 4096
+    },
+    "quality": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "Quality level of the playback (e.g., 1080p).",
+      "maxLength": 4096
+    },
+    "volume": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "description": "Volume percentage at which the media will be played.",
+      "minimum": 0,
+      "maximum": 100
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "currentTime",
+    "ended",
+    "paused"
+  ]
+}

--- a/schemas/com.snowplowanalytics.snowplow.media/session/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.snowplow.media/session/jsonschema/1-0-0
@@ -1,0 +1,138 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Schema for a context entity for media player events that tracks a session of a single media player usage",
+  "self": {
+    "vendor": "com.snowplowanalytics.snowplow.media",
+    "name": "session",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "type": "object",
+  "properties": {
+    "mediaSessionId": {
+      "type": "string",
+      "maxLength": 256,
+      "description": "An identifier for the media session that is kept while the media content is played in the media player."
+    },
+    "startedAt": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "description": "Local date-time timestamp of when the session started.",
+      "format": "date-time"
+    },
+    "pingInterval": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "description": "Interval (seconds) in which the ping events will be sent. Default (specified in the tracker media docs) is assumed if not specified.",
+      "minimum": 0,
+      "maximum": 65535
+    },
+    "timePlayed": {
+      "type": [
+        "number",
+        "null"
+      ],
+      "description": "Total seconds user spent playing content (excluding linear ads).",
+      "minimum": 0,
+      "maximum": 2147483647
+    },
+    "timePlayedMuted": {
+      "type": [
+        "number",
+        "null"
+      ],
+      "description": "Total seconds user spent playing content on mute (excluding linear ads).",
+      "minimum": 0,
+      "maximum": 2147483647
+    },
+    "timePaused": {
+      "type": [
+        "number",
+        "null"
+      ],
+      "description": "Total seconds user spent with paused content (excluding linear ads).",
+      "minimum": 0,
+      "maximum": 2147483647
+    },
+    "contentWatched": {
+      "type": [
+        "number",
+        "null"
+      ],
+      "description": "Total seconds of the content played. Each part of the content played is counted once (i.e., counts rewinding or rewatching the same content only once). Playback rate does not affect this value.",
+      "minimum": 0,
+      "maximum": 2147483647
+    },
+    "timeBuffering": {
+      "type": [
+        "number",
+        "null"
+      ],
+      "description": "Total seconds that playback was buffering during the session.",
+      "minimum": 0,
+      "maximum": 2147483647
+    },
+    "timeSpentAds": {
+      "type": [
+        "number",
+        "null"
+      ],
+      "description": "Total seconds that ads played during the session.",
+      "minimum": 0,
+      "maximum": 2147483647
+    },
+    "ads": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "description": "Number of ads played.",
+      "minimum": 0,
+      "maximum": 65535
+    },
+    "adsClicked": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "description": "Number of ads that the user clicked on.",
+      "minimum": 0,
+      "maximum": 65535
+    },
+    "adsSkipped": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "description": "Number of ads that the user skipped.",
+      "minimum": 0,
+      "maximum": 65535
+    },
+    "adBreaks": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "description": "Number of ad breaks played.",
+      "minimum": 0,
+      "maximum": 65535
+    },
+    "avgPlaybackRate": {
+      "type": [
+        "number",
+        "null"
+      ],
+      "description": "Average playback rate (1 is normal speed).",
+      "minimum": 0,
+      "maximum": 16
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "mediaSessionId"
+  ]
+}


### PR DESCRIPTION
Schemas for new context entities that will be attached to media player events to enable:

* tracking a session that groups all events coming from the same media player,
* tracking ads within media,
* tracking media player quality.

## `media_player_session` (#1266)

A session groups events from the same media player using a `sessionId` identifier (which may be provided by the user).

A secondary role of the session is a sort of edge analytics since it provides statistics about the playback (such as the time spent playing) in order to make data modelling more efficient.

## `media_player_ad_break` (#1268)

An ad break is a grouping of ads played back to back. The schema will identify all ad events belonging to the same ad break.

## `media_player_ad` (#1267)

Describes an ad being played at the time of the event. Provide metadata about the ad.

## `media_player_quality` (#1269)

Describes quality of experience for the media playback at a specific time. It will be tracked with `updateQuality` media player events so it will give a snapshot of the data quality rather than aggregated metrics for the whole playback.