### PR TITLE
Vimeo Entities

### DIFF
--- a/schemas/com.vimeo/chapter_change_event/jsonschema/1-0-0
+++ b/schemas/com.vimeo/chapter_change_event/jsonschema/1-0-0
@@ -1,0 +1,40 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Schema for a Vimeo chapter change event fired when the current chapter changes.",
+  "self": {
+    "vendor": "com.vimeo",
+    "name": "chapter_change_event",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "type": "object",
+  "properties": {
+    "index": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "description": "The chapter number.",
+      "maximum": 100,
+      "minimum": 1
+    },
+    "startTime": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "description": "The time in seconds when the chapter begins.",
+      "maximum": 2147483647,
+      "minimum": 0
+    },
+    "title": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "The chapter title.",
+      "maxLength": 4096
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/com.vimeo/cue_point_event/jsonschema/1-0-0
+++ b/schemas/com.vimeo/cue_point_event/jsonschema/1-0-0
@@ -1,0 +1,37 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Schema for a Vimeo cue point event, fired when a cue point is reached in a video.",
+  "self": {
+    "vendor": "com.vimeo",
+    "name": "cue_point_event",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "format": "uuid",
+      "description": "The ID of the cue point."
+    },
+    "cuePointTime": {
+      "type": "number",
+      "description": "The location of the cue point in seconds.",
+      "minimum": 0,
+      "maximum": 2147483647
+    },
+    "data": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "description": "The custom data from the addCuePoint() call, or an empty object.",
+      "additionalProperties": true
+    }
+  },
+  "required": [
+    "id",
+    "cuePointTime"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/com.vimeo/interaction/jsonschema/1-0-0
+++ b/schemas/com.vimeo/interaction/jsonschema/1-0-0
@@ -1,0 +1,114 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Context Schema attached to interactive_hotspot_click_event and interactive_overlay_panel_click_event.",
+  "self": {
+    "vendor": "com.vimeo",
+    "name": "interaction",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "type": "object",
+  "properties": {
+    "action": {
+      "type": "string",
+      "description": "The action type of the hotspot.",
+      "maxLength": 4096
+    },
+    "actionPreference": {
+      "type": "object",
+      "description": "The user's preferred action type for the hotspot.",
+      "properties": {
+        "pauseOnAction": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "description": "Whether to pause when the action type is overlay, url, seek, event, or none."
+        },
+        "overlayId": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "When action is overlay, the displayed unique ID for the overlay when the hotspot is clicked.",
+          "maxLength": 4096
+        },
+        "seekTo": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "When action is seek, the time in seconds that the video should jump to when the hotspot is clicked.",
+          "minimum": 0,
+          "maximum": 2147483647
+        },
+        "seekToFrame": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "description": "When action is seek, the frame that the video should jump to when the hotspot is clicked.",
+          "minimum": 0,
+          "maximum": 2147483647
+        },
+        "url": {
+          "format": "uri",
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "When action is clickthrough, the target URL when the overlay panel is clicked.",
+          "maxLength": 4096
+        }
+      },
+      "additionalProperties": false
+    },
+    "customPayloadData": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "description": "The custom payload data of the interactive hotspot",
+      "additionalProperties": true
+    },
+    "currentTime": {
+      "type": [
+        "number",
+        "null"
+      ],
+      "description": "The current time of the video when the interaction occurs is clicked.",
+      "minimum": 0,
+      "maximum": 2147483647
+    },
+    "hotspotId": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "The unique ID for the hotspot.",
+      "maxLength": 4096
+    },
+    "panelId": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "The unique ID for a panel within the overlay.",
+      "maxLength": 36,
+      "minLength": 1
+    },
+    "overlayId": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "When action is overlay, the displayed unique ID for the overlay when the hotspot is clicked.",
+      "maxLength": 4096
+    }
+  },
+  "required": [
+    "action",
+    "actionPreference"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/com.vimeo/interactive_hotspot_click_event/jsonschema/1-0-0
+++ b/schemas/com.vimeo/interactive_hotspot_click_event/jsonschema/1-0-0
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Schema for a Vimeo interactive video hotspot click",
+  "self": {
+    "vendor": "com.vimeo",
+    "name": "interactive_hotspot_click_event",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "type": "object",
+  "properties": {},
+  "additionalProperties": false
+}

--- a/schemas/com.vimeo/interactive_overlay_panel_click_event/jsonschema/1-0-0
+++ b/schemas/com.vimeo/interactive_overlay_panel_click_event/jsonschema/1-0-0
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Schema for a Vimeo interactive overlay panel click",
+  "self": {
+    "vendor": "com.vimeo",
+    "name": "interactive_overlay_panel_click_event",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "type": "object",
+  "properties": {},
+  "additionalProperties": false
+}

--- a/schemas/com.vimeo/meta/jsonschema/1-0-0
+++ b/schemas/com.vimeo/meta/jsonschema/1-0-0
@@ -1,0 +1,52 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Schema for a Vimeo video metadata.",
+  "self": {
+    "vendor": "com.vimeo",
+    "name": "meta",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "type": "object",
+  "properties": {
+    "videoId": {
+      "type": "number",
+      "description": "The Vimeo ID of the video.",
+      "minimum": 0,
+      "maximum": 9223372036854776000
+    },
+    "videoTitle": {
+      "type": "string",
+      "description": "The title of the video.",
+      "maxLength": 4096
+    },
+    "videoUrl": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "format": "uri",
+      "description": "The URL of the video on vimeo.com.",
+      "maxLength": 4096
+    },
+    "videoWidth": {
+      "type": "number",
+      "description": "The native width of the video as the width of the video's highest available resolution.",
+      "minimum": 0,
+      "maximum": 9223372036854776000
+    },
+    "videoHeight": {
+      "type": "number",
+      "description": "The native height of the video as the height of the video's highest available resolution.",
+      "minimum": 0,
+      "maximum": 9223372036854776000
+    }
+  },
+  "required": [
+    "videoId",
+    "videoTitle",
+    "videoWidth",
+    "videoHeight"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/com.vimeo/text_track_change_event/jsonschema/1-0-0
+++ b/schemas/com.vimeo/text_track_change_event/jsonschema/1-0-0
@@ -1,0 +1,46 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Schema for a Vimeo text track event, fired when the active text track of the captions or subtitle kind changes.",
+  "self": {
+    "vendor": "com.vimeo",
+    "name": "text_track_change_event",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "type": "object",
+  "properties": {
+    "kind": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "The kind of the text track: 'captions' or 'subtitles'.",
+      "maxLength": 4096
+    },
+    "language": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "The ISO code of the text track's language.",
+      "maxLength": 4096
+    },
+    "label": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "The human-readable label of the text track for identification purposes.",
+      "maxLength": 4096
+    },
+    "mode": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "The mode of the text track",
+      "maxLength": 4096
+    }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
Entities required for Vimeo video tracking.

The majority of events are handled by the [media event schemas](https://github.com/snowplow/iglu-central/pull/1302) released with the Snowplow Media plugin, but there are a few vimeo-specific schemas required:

## com.vimeo/meta/jsonschema/1-0-0

Context schema with information about the video, the Vimeo id, title, URL, and dimension.

## com.vimeo/text_track_event/jsonschema/1-0-0

Information about a [text track](https://developer.vimeo.com/player/sdk/reference#texttrackchange)

## com.vimeo/interactive_hotspot_click_event/jsonschema/1-0-0

Event schema for a hotspot click

## com.vimeo/interactive_overlay_panel_click_event/jsonschema/1-0-0

Event schema for an overlay panel click

## com.vimeo/interaction/jsonschema/1-0-0

Context schema for `interactive_overlay_panel_click_event` and `interactive_hotspot_click_event` schemas

Specific to Vimeos "[interactive](https://vimeo.com/features/interactive-video)" videos. Despite the [docs](https://developer.vimeo.com/player/sdk/reference#events-for-interactive-videos) for these events showing the expected structure, there were a couple of differences I discovered during testing:
- `overlayId` is a string, shown as a number in the docs
- `hotspotId` is also a string, shown as a number in the docs

There are two slightly different structures for interaction, depending on the event (either `interactiveoverlaypanelclicked` and `interactivehotspotclicked`). I've merged them into a single "interaction" schema for simplicity, but it may be worth splitting them out into separate schemas, especially as `overlayId` appears twice due to the merging.

## com.vimeo/schemas/cue_point_event/jsonschema/1-0-0

Information about a Vimeo [cuepoint](https://developer.vimeo.com/player/sdk/reference#events-for-cue-points).

## com.vimeo/schemas/chapter_change_event/jsonschema/1-0-0

Information about a Vimeo [chapter](https://developer.vimeo.com/player/sdk/reference#methods-for-chapters).

