### PR TITLE
Add media player event schemas

### DIFF
--- a/schemas/com.snowplowanalytics.snowplow.media/ad_break_end_event/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.snowplow.media/ad_break_end_event/jsonschema/1-0-0
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Media player event that signals the end of an ad break.",
+  "self": {
+    "vendor": "com.snowplowanalytics.snowplow.media",
+    "name": "ad_break_end_event",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "type": "object",
+  "properties": {
+  },
+  "additionalProperties": false
+}

--- a/schemas/com.snowplowanalytics.snowplow.media/ad_break_start_event/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.snowplow.media/ad_break_start_event/jsonschema/1-0-0
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Media player event that signals the start of an ad break.",
+  "self": {
+    "vendor": "com.snowplowanalytics.snowplow.media",
+    "name": "ad_break_start_event",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "type": "object",
+  "properties": {
+  },
+  "additionalProperties": false
+}

--- a/schemas/com.snowplowanalytics.snowplow.media/ad_click_event/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.snowplow.media/ad_click_event/jsonschema/1-0-0
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Media player event fired when the user clicked on the ad.",
+  "self": {
+    "vendor": "com.snowplowanalytics.snowplow.media",
+    "name": "ad_click_event",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "type": "object",
+  "properties": {
+    "percentProgress": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "description": "The percent of the way through the ad",
+      "minimum": 0,
+      "maximum": 100
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/com.snowplowanalytics.snowplow.media/ad_complete_event/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.snowplow.media/ad_complete_event/jsonschema/1-0-0
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Media player event that signals the ad creative was played to the end at normal speed.",
+  "self": {
+    "vendor": "com.snowplowanalytics.snowplow.media",
+    "name": "ad_complete_event",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "type": "object",
+  "properties": {},
+  "additionalProperties": false
+}

--- a/schemas/com.snowplowanalytics.snowplow.media/ad_pause_event/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.snowplow.media/ad_pause_event/jsonschema/1-0-0
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Media player event fired when the user clicked the pause control and stopped the ad creative.",
+  "self": {
+    "vendor": "com.snowplowanalytics.snowplow.media",
+    "name": "ad_pause_event",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "type": "object",
+  "properties": {
+    "percentProgress": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "description": "The percent of the way through the ad",
+      "minimum": 0,
+      "maximum": 100
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/com.snowplowanalytics.snowplow.media/ad_quartile_event/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.snowplow.media/ad_quartile_event/jsonschema/1-0-0
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Media player event fired when a quartile of ad is reached after continuous ad playback at normal speed.",
+  "self": {
+    "vendor": "com.snowplowanalytics.snowplow.media",
+    "name": "ad_quartile_event",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "type": "object",
+  "properties": {
+    "percentProgress": {
+      "type": "integer",
+      "description": "The percent of the way through the ad",
+      "minimum": 0,
+      "maximum": 100
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "percentProgress"
+  ]
+}

--- a/schemas/com.snowplowanalytics.snowplow.media/ad_resume_event/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.snowplow.media/ad_resume_event/jsonschema/1-0-0
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Media player event fired when the user resumed playing the ad creative after it had been stopped or paused.",
+  "self": {
+    "vendor": "com.snowplowanalytics.snowplow.media",
+    "name": "ad_resume_event",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "type": "object",
+  "properties": {
+    "percentProgress": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "description": "The percent of the way through the ad",
+      "minimum": 0,
+      "maximum": 100
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/com.snowplowanalytics.snowplow.media/ad_skip_event/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.snowplow.media/ad_skip_event/jsonschema/1-0-0
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Media player event fired when the user activated a skip control to skip the ad creative.",
+  "self": {
+    "vendor": "com.snowplowanalytics.snowplow.media",
+    "name": "ad_skip_event",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "type": "object",
+  "properties": {
+    "percentProgress": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "description": "The percent of the way through the ad",
+      "minimum": 0,
+      "maximum": 100
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/com.snowplowanalytics.snowplow.media/ad_start_event/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.snowplow.media/ad_start_event/jsonschema/1-0-0
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Media player event that signals the start of an ad.",
+  "self": {
+    "vendor": "com.snowplowanalytics.snowplow.media",
+    "name": "ad_start_event",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "type": "object",
+  "properties": {},
+  "additionalProperties": false
+}

--- a/schemas/com.snowplowanalytics.snowplow.media/buffer_end_event/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.snowplow.media/buffer_end_event/jsonschema/1-0-0
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Media player event fired when the the player finishes buffering content and resumes playback.",
+  "self": {
+    "vendor": "com.snowplowanalytics.snowplow.media",
+    "name": "buffer_end_event",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "type": "object",
+  "properties": {},
+  "additionalProperties": false
+}

--- a/schemas/com.snowplowanalytics.snowplow.media/buffer_start_event/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.snowplow.media/buffer_start_event/jsonschema/1-0-0
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Media player event fired when the player goes into the buffering state and begins to buffer content.",
+  "self": {
+    "vendor": "com.snowplowanalytics.snowplow.media",
+    "name": "buffer_start_event",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "type": "object",
+  "properties": {},
+  "additionalProperties": false
+}

--- a/schemas/com.snowplowanalytics.snowplow.media/end_event/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.snowplow.media/end_event/jsonschema/1-0-0
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Media player event sent when playback stops when end of the media is reached or because no further data is available.",
+  "self": {
+    "vendor": "com.snowplowanalytics.snowplow.media",
+    "name": "end_event",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "type": "object",
+  "properties": {},
+  "additionalProperties": false
+}

--- a/schemas/com.snowplowanalytics.snowplow.media/error_event/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.snowplow.media/error_event/jsonschema/1-0-0
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Media player event tracked when the resource could not be loaded due to an error.",
+  "self": {
+    "vendor": "com.snowplowanalytics.snowplow.media",
+    "name": "error_event",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "type": "object",
+  "properties": {
+    "errorCode": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "Error-identifying code for the playback issue. E.g. E522",
+      "maxLength": 256
+    },
+    "errorName": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "Name for the type of error that occurred in the playback. E.g. forbidden",
+      "maxLength": 256
+    },
+    "errorDescription": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "Longer description for the error that occurred in the playback.",
+      "maxLength": 4096
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/com.snowplowanalytics.snowplow.media/fullscreen_change_event/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.snowplow.media/fullscreen_change_event/jsonschema/1-0-0
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Media player event fired immediately after the browser switches into or out of full-screen mode.",
+  "self": {
+    "vendor": "com.snowplowanalytics.snowplow.media",
+    "name": "fullscreen_change_event",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "type": "object",
+  "properties": {
+    "fullscreen": {
+      "type": "boolean",
+      "description": "Whether the video element is fullscreen after the change"
+    }
+  },
+  "required": [
+    "fullscreen"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/com.snowplowanalytics.snowplow.media/pause_event/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.snowplow.media/pause_event/jsonschema/1-0-0
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Media player event sent when the user pauses the playback.",
+  "self": {
+    "vendor": "com.snowplowanalytics.snowplow.media",
+    "name": "pause_event",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "type": "object",
+  "properties": {},
+  "additionalProperties": false
+}

--- a/schemas/com.snowplowanalytics.snowplow.media/percent_progress_event/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.snowplow.media/percent_progress_event/jsonschema/1-0-0
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Media player event fired when a percentage boundary set in tracking options is reached",
+  "self": {
+    "vendor": "com.snowplowanalytics.snowplow.media",
+    "name": "percent_progress_event",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "type": "object",
+  "properties": {
+    "percentProgress": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "description": "The percent of the way through the media",
+      "minimum": 0,
+      "maximum": 100
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/com.snowplowanalytics.snowplow.media/picture_in_picture_change_event/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.snowplow.media/picture_in_picture_change_event/jsonschema/1-0-0
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Media player event fired immediately after the browser switches into or out of picture-in-picture mode.",
+  "self": {
+    "vendor": "com.snowplowanalytics.snowplow.media",
+    "name": "picture_in_picture_change_event",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "type": "object",
+  "properties": {
+    "pictureInPicture": {
+      "type": "boolean",
+      "description": "Whether the video element is showing picture-in-picture after the change."
+    }
+  },
+  "required": [
+    "pictureInPicture"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/com.snowplowanalytics.snowplow.media/ping_event/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.snowplow.media/ping_event/jsonschema/1-0-0
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Media player event fired periodically during main content playback, regardless of other API events that have been sent.",
+  "self": {
+    "vendor": "com.snowplowanalytics.snowplow.media",
+    "name": "ping_event",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "type": "object",
+  "properties": {
+  },
+  "additionalProperties": false
+}

--- a/schemas/com.snowplowanalytics.snowplow.media/play_event/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.snowplow.media/play_event/jsonschema/1-0-0
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Media player event sent when the player changes state to playing from previously being paused.",
+  "self": {
+    "vendor": "com.snowplowanalytics.snowplow.media",
+    "name": "play_event",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "type": "object",
+  "properties": {},
+  "additionalProperties": false
+}

--- a/schemas/com.snowplowanalytics.snowplow.media/playback_rate_change_event/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.snowplow.media/playback_rate_change_event/jsonschema/1-0-0
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Media player event sent when the playback rate has changed.",
+  "self": {
+    "vendor": "com.snowplowanalytics.snowplow.media",
+    "name": "playback_rate_change_event",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "type": "object",
+  "properties": {
+    "previousRate": {
+      "type": [
+        "number",
+        "null"
+      ],
+      "description": "Playback rate before the change (1 is normal)",
+      "minimum": 0,
+      "maximum": 16
+    },
+    "newRate": {
+      "type": "number",
+      "description": "Playback rate after the change (1 is normal)",
+      "minimum": 0,
+      "maximum": 16
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/com.snowplowanalytics.snowplow.media/quality_change_event/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.snowplow.media/quality_change_event/jsonschema/1-0-0
@@ -1,0 +1,55 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Media player event tracked when the video playback quality changes automatically.",
+  "self": {
+    "vendor": "com.snowplowanalytics.snowplow.media",
+    "name": "quality_change_event",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "type": "object",
+  "properties": {
+    "previousQuality": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "Quality level before the change (e.g., 1080p).",
+      "maxLength": 4096
+    },
+    "newQuality": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "Quality level after the change (e.g., 1080p).",
+      "maxLength": 4096
+    },
+    "bitrate": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "description": "The current bitrate in bits per second.",
+      "minimum": 0,
+      "maximum": 9007199254740991
+    },
+    "framesPerSecond": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "description": "The current number of frames per second.",
+      "minimum": 0,
+      "maximum": 65535
+    },
+    "automatic": {
+      "type": [
+        "boolean",
+        "null"
+      ],
+      "description": "Whether the change was automatic or triggered by the user."
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/com.snowplowanalytics.snowplow.media/ready_event/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.snowplow.media/ready_event/jsonschema/1-0-0
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Media player event fired when the media tracking is successfully attached to the player and can track events.",
+  "self": {
+    "vendor": "com.snowplowanalytics.snowplow.media",
+    "name": "ready_event",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "type": "object",
+  "properties": {},
+  "additionalProperties": false
+}

--- a/schemas/com.snowplowanalytics.snowplow.media/seek_end_event/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.snowplow.media/seek_end_event/jsonschema/1-0-0
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Media player event sent when a seek operation completes.",
+  "self": {
+    "vendor": "com.snowplowanalytics.snowplow.media",
+    "name": "seek_end_event",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "type": "object",
+  "properties": {},
+  "additionalProperties": false
+}

--- a/schemas/com.snowplowanalytics.snowplow.media/seek_start_event/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.snowplow.media/seek_start_event/jsonschema/1-0-0
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Media player event sent when a seek operation begins.",
+  "self": {
+    "vendor": "com.snowplowanalytics.snowplow.media",
+    "name": "seek_start_event",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "type": "object",
+  "properties": {},
+  "additionalProperties": false
+}

--- a/schemas/com.snowplowanalytics.snowplow.media/volume_change_event/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.snowplow.media/volume_change_event/jsonschema/1-0-0
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Media player event sent when the volume has changed.",
+  "self": {
+    "vendor": "com.snowplowanalytics.snowplow.media",
+    "name": "volume_change_event",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "type": "object",
+  "properties": {
+    "previousVolume": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "description": "Volume percentage before the change.",
+      "minimum": 0,
+      "maximum": 100
+    },
+    "newVolume": {
+      "type": "integer",
+      "description": "Volume percentage after the change.",
+      "minimum": 0,
+      "maximum": 100
+    }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
This PR separates out the different event types that we previously represented in the [media_player_event](https://github.com/snowplow/iglu-central/blob/master/schemas/com.snowplowanalytics.snowplow/media_player_event/jsonschema/1-0-0) into separate event schemas. The reasons for separating out the schemas are:

1. Make it more efficient to filter events in modelling using their schemas instead of having to dive into the `type` property.
2. Enable real-time use cases where one would subscribe to the particular event schemas that they are interested in.
3. Improve validation (previously the `type` property was a string without any validation).

Each of the schemas contain the `label` property as the `media_player_event`:

Request Key | Required | Type/Format | Description
-- | -- | -- | --
label | N | string | A custom identifier for the media player

In addition to the existing event types, there are several new ones for ads and data quality tracking.

### Event schemas for controlling the playback

Event schema | Description
-- | --
media_player_event_ready | Media player event fired when the media tracking is successfully attached to the player and can track events.
media_player_event_play | Media player event sent when the player changes state to playing from previously being paused.
media_player_event_pause | Media player event sent when the user pauses the playback.
media_player_event_end | Media player event sent when playback stops when end of the media is reached or because no further data is available.
media_player_event_seek_start | Media player event sent when a seek operation begins.
media_player_event_seek_end | Media player event sent when a seek operation completes.

### Event schemas for changes in playback settings

Event schema | Description
-- | --
media_player_event_playbackrate_change | Media player event sent when the playback rate has changed.
media_player_event_volume_change | Media player event sent when the volume has changed.
media_player_event_fullscreen_change | Media player event fired immediately after the browser switches into or out of full-screen mode.
media_player_event_pictureinpicture_change | Media player event fired immediately after the browser switches into or out of picture-in-picture mode.

### Event schemas for tracking playback progress

Event schema | Description
-- | --
media_player_event_ping | Media player event fired periodicaly during main content playback, regardless of other API events that have been sent.
media_player_event_percent_progress | Media player event fired when a percentage boundary set in options.boundaries is reached

### Event schemas for ad events

Event schema | Description
-- | --
media_player_event_ad_break_start | Media player event that signals the start of an ad break.
media_player_event_ad_break_end | Media player event that signals the end of an ad break.
media_player_event_ad_start | Media player event that signals the start of an ad.
media_player_event_ad_percent_progress | Media player event fired when a percentage boundary is reached after continuous ad playback at normal speed.
media_player_event_ad_complete | Media player event that signals the ad creative was played to the end at normal speed.
media_player_event_ad_skip | Media player event fired when the user activated a skip control to skip the ad creative.
media_player_event_ad_click | Media player event fired when the user clicked on the ad.
media_player_event_ad_pause | Media player event fired when the user clicked the pause control and stopped the ad creative.
media_player_event_ad_resume | Media player event fired when the user resumed playing the ad creative after it had been stopped or paused.

### Event schemas for data quality

Event schema | Description
-- | --
media_player_event_buffer_start | Media player event fired when the player goes into the buffering state and begins to buffer content.
media_player_event_buffer_end | Media player event fired when the the player finishes buffering content and resumes playback.
media_player_event_quality_change | Media player event tracked when the video playback quality changes automatically. It is accompanied with the media_player_quality schema.
media_player_event_user_update_quality | Media player event tracked when the video playback quality changes as a result of user interaction (choosing a different quality setting). It is accompanied with the media_player_quality schema.
media_player_event_error | Media player event tracked when the resource could not be loaded due to an error.