### PR TITLE
Badrows with supersededby

### DIFF
--- a/schemas/com.snowplowanalytics.snowplow.badrows/enrichment_failures/jsonschema/2-0-1
+++ b/schemas/com.snowplowanalytics.snowplow.badrows/enrichment_failures/jsonschema/2-0-1
@@ -1,0 +1,493 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Schema for a bad row resulting from enrichment failures",
+  "self": {
+    "vendor": "com.snowplowanalytics.snowplow.badrows",
+    "name": "enrichment_failures",
+    "format": "jsonschema",
+    "version": "2-0-1"
+  },
+  "type": "object",
+  "properties": {
+    "failure": {
+      "type": "object",
+      "description": "Information regarding the enrichment failures",
+      "properties": {
+        "timestamp": {
+          "type": "string",
+          "description": "Timestamp at which the failure occurred",
+          "format": "date-time"
+        },
+        "messages": {
+          "type": "array",
+          "description": "List of failure messages associated with the enrichment failures",
+          "items": {
+            "type": "object",
+            "description": "Individual enrichment failure or null in case of validation",
+            "properties": {
+              "enrichment": {
+                "type": ["object", "null"],
+                "description": "Information needed to identify an enrichment",
+                "properties": {
+                  "schemaKey": {
+                    "type": "string",
+                    "description": "The schema coordinates for this enrichment"
+                  },
+                  "identifier": {
+                    "type": "string",
+                    "description": "Uniquely identifies the instance of of the enrichment which produced this failure",
+                    "maxLength": 256
+                  }
+                },
+                "required": [ "schemaKey", "identifier" ],
+                "additionalProperties": false
+              },
+              "message": {
+                "type": "object",
+                "description": "Information about the failure that happened for this enrichment",
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "description": "Error which was internal to the enrichment regarding its input data",
+                    "properties": {
+                      "field": {
+                        "type": "string",
+                        "description": "Field which did not meet the enrichment's expectations",
+                        "maxLength": 64
+                      },
+                      "value": {
+                        "type": [ "string", "null" ],
+                        "description": "Stringified representation of the value which did not meet expectations"
+                      },
+                      "expectation": {
+                        "type": "string",
+                        "description": "Expectation which was not met",
+                        "maxLength": 256
+                      }
+                    },
+                    "required": ["field", "expectation" ],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "description": "Error which was external to the enrichment, e.g. a connection issue",
+                    "properties": {
+                      "error": {
+                        "type": "string",
+                        "description": "Error that occurred",
+                        "maxLength": 512
+                      }
+                    },
+                    "required": [ "error" ],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "description": "Supplied JSON did not validate against its schema (or schema was not found)",
+                    "properties": {
+                      "schemaKey": {
+                        "type": "string",
+                        "description": "The iglu schema coordinates to validate against"
+                      },
+                      "error": {
+                        "description": "Iglu client error",
+                        "anyOf": [
+                          {
+                            "description": "Resolution error - schema could not be found in the specified repositories, defined by ResolutionError in the Iglu Client",
+                            "properties": {
+                              "error": {
+                                "enum": ["ResolutionError"]
+                              },
+                              "lookupHistory": {
+                                "type": "array",
+                                "minItems": 1,
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "repostitory": {
+                                      "type": "string",
+                                      "description": "Name of the repostitory as written in resolver.json"
+                                    },
+                                    "errors": {
+                                      "description": "Set of errors which happened for this repository",
+                                      "type": "array",
+                                      "minItems": 1,
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "error": {
+                                            "description": "Type of error (NotFound does not contain a message)",
+                                            "enum": ["RepoFailure", "ClientFailure", "NotFound"]
+                                          },
+                                          "message": {
+                                            "description": "Optional message in case of ClientFailure or RepoFailure",
+                                            "type": "string",
+                                            "maxLength": 256
+                                          }
+                                        },
+                                        "required": ["error" ]
+                                      }
+                                    },
+                                    "attempts": {
+                                      "type": "integer",
+                                      "minimum": 0,
+                                      "description": "Number of attempts which have been made"
+                                    },
+                                    "lastAttempt": {
+                                      "type": "string",
+                                      "format": "date-time",
+                                      "description": "Timestamp of a last attempt being made"
+                                    }
+                                  },
+                                  "required": ["repository", "errors", "attempts", "lastAttempt"]
+                                }
+                              }
+                            },
+                            "required": [ "error", "lookupHistory" ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "description": "Data is invalid against resolved schema",
+                            "properties": {
+                              "error": {
+                                "enum": ["ValidationError"]
+                              },
+                              "supersededBy": {
+                                "type": ["string", "null"],
+                                "description": "Superseding schema version if original schema is superseded by another schema",
+                                "maxLength": 32
+                              },
+                              "dataReports": {
+                                "type": "array",
+                                "minItems": 1,
+                                "items": {
+                                  "properties": {
+                                    "message": {
+                                      "type": "string",
+                                      "description": "Human-readable message describing the issue with the schema"
+                                    },
+                                    "path": {
+                                      "type": ["string", "null"],
+                                      "description": "JSON Path to an issue in the faulty JSON datum"
+                                    },
+                                    "keyword": {
+                                      "type": ["string", "null"],
+                                      "description": "JSON Schema Keywrod caused invalidation"
+                                    },
+                                    "targets": {
+                                      "type": ["array", "null"]
+                                    }
+                                  },
+                                  "required": [ "path", "message", "keyword", "targets" ],
+                                  "additionalProperties": false
+                                }
+                              }
+                            },
+                            "required": [ "dataReports" ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "description": "Schema is invalid and cannot be used to validate an instance",
+                            "properties": {
+                              "error": {
+                                "enum": ["ValidationError"]
+                              },
+                              "supersededBy": {
+                                "type": ["string", "null"],
+                                "description": "Superseding schema version if original schema is superseded by another schema",
+                                "maxLength": 32
+                              },
+                              "schemaIssues": {
+                                "description": "List of problems in resolved JSON schema",
+                                "type": "array",
+                                "minItems": 1,
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "path": {
+                                      "type": "string",
+                                      "description": "JSON Path to an issue in the faulty JSON Schema"
+                                    },
+                                    "message": {
+                                      "type": "string",
+                                      "description": "Human-readable message describing the issue with the schema"
+                                    }
+                                  },
+                                  "required": [ "path", "message" ],
+                                  "additionalProperties": false
+                                }
+                              }
+                            },
+                            "required": [ "error" ],
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                ]
+              }
+            },
+            "required": [ "enrichment", "message" ],
+            "additionalProperties": false
+          }
+        }
+      }
+    },
+    "payload": {
+      "type": "object",
+      "properties": {
+        "raw": {
+          "type": "object",
+          "description": "The raw event extracted from collector payload",
+          "properties": {
+            "vendor": {
+              "type": "string",
+              "description": "Vendor of the adapter that processed this payload, here com.snowplowanalytics.snowplow",
+              "maxLength": 64
+            },
+            "version": {
+              "type": "string",
+              "description": "Version of the adapter that processed this payload",
+              "maxLength": 16
+            },
+            "parameters": {
+              "type": [ "array", "null" ],
+              "description": "Query string of the collector payload containing this event",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "Name of the querystring parameter",
+                    "maxLength": 512
+                  },
+                  "value": {
+                    "type": [ "string", "null" ],
+                    "description": "Possible value for the querystring parameter",
+                    "maxLength": 512
+                  }
+                },
+                "required": [ "name", "value" ],
+                "additionalProperties": false
+              }
+            },
+            "contentType": {
+              "type": [ "string", "null" ],
+              "description": "Content type of the payload as detected by the collector",
+              "maxLength": 256
+            },
+            "loaderName": {
+              "type": "string",
+              "maxLength": 32
+            },
+            "encoding": {
+              "type": "string",
+              "description": "Encoding of the collector payload",
+              "maxLength": 32
+            },
+            "hostname": {
+              "type": [ "string", "null" ],
+              "description": "Hostname of the payload as detected by the collector",
+              "maxLength": 8192
+            },
+            "timestamp": {
+              "type": ["string", "null"],
+              "description": "Timestamp at which the payload was collected",
+              "format": "date-time"
+            },
+            "ipAddress": {
+              "type": ["string", "null"],
+              "description": "IP address of the payload as detected by the collector",
+              "maxLength": 128
+            },
+            "useragent": {
+              "type": [ "string", "null" ],
+              "description": "User agent of the payload as detected by the collector",
+              "maxLength": 4096
+            },
+            "refererUri": {
+              "type": [ "string", "null" ],
+              "description": "Referer of the payload as detected by the collector",
+              "maxLength": 8192
+            },
+            "headers": {
+              "type": [ "array", "null" ],
+              "description": "List of the headers part of this collector payload",
+              "items": {
+                "type": "string",
+                "maxLength": 8192
+              }
+            },
+            "userId": {
+              "type": [ "string", "null" ],
+              "description": "Network user id associated with this payload",
+              "format": "uuid"
+            }
+          },
+          "required": [ "vendor", "version", "loaderName", "encoding" ],
+          "additionalProperties": false
+        },
+        "enriched": {
+          "description": "The partially enriched event that resulted in schema violations",
+          "properties": {
+            "app_id": { "type": ["string", "null"] },
+            "platform": { "type": ["string", "null"] },
+            "etl_tstamp": { "type": ["string", "null"] },
+            "collector_tstamp": { "type": ["string", "null"] },
+            "dvce_created_tstamp": { "type": ["string", "null"] },
+            "event": { "type": ["string", "null"] },
+            "event_id": { "type": ["string", "null"] },
+            "txn_id": { "type": ["string", "null"] },
+            "name_tracker": { "type": ["string", "null"] },
+            "v_tracker": { "type": ["string", "null"] },
+            "v_collector": { "type": ["string", "null"] },
+            "v_etl": { "type": ["string", "null"] },
+            "user_id": { "type": ["string", "null"] },
+            "user_ipaddress": { "type": ["string", "null"] },
+            "user_fingerprint": { "type": ["string", "null"] },
+            "domain_userid": { "type": ["string", "null"] },
+            "domain_sessionidx": { "type": ["integer", "null"] },
+            "network_userid": { "type": ["string", "null"] },
+            "geo_country": { "type": ["string", "null"] },
+            "geo_region": { "type": ["string", "null"] },
+            "geo_city": { "type": ["string", "null"] },
+            "geo_zipcode": { "type": ["string", "null"] },
+            "geo_latitude": { "type": ["number", "null"] },
+            "geo_longitude": { "type": ["number", "null"] },
+            "geo_region_name": { "type": ["string", "null"] },
+            "ip_isp": { "type": ["string", "null"] },
+            "ip_organization": { "type": ["string", "null"] },
+            "ip_domain": { "type": ["string", "null"] },
+            "ip_netspeed": { "type": ["string", "null"] },
+            "page_url": { "type": ["string", "null"] },
+            "page_title": { "type": ["string", "null"] },
+            "page_referrer": { "type": ["string", "null"] },
+            "page_urlscheme": { "type": ["string", "null"] },
+            "page_urlhost": { "type": ["string", "null"] },
+            "page_urlport": { "type": ["integer", "null"] },
+            "page_urlpath": { "type": ["string", "null"] },
+            "page_urlquery": { "type": ["string", "null"] },
+            "page_urlfragment": { "type": ["string", "null"] },
+            "refr_urlscheme": { "type": ["string", "null"] },
+            "refr_urlhost": { "type": ["string", "null"] },
+            "refr_urlport": { "type": ["integer", "null"] },
+            "refr_urlpath": { "type": ["string", "null"] },
+            "refr_urlquery": { "type": ["string", "null"] },
+            "refr_urlfragment": { "type": ["string", "null"] },
+            "refr_medium": { "type": ["string", "null"] },
+            "refr_source": { "type": ["string", "null"] },
+            "refr_term": { "type": ["string", "null"] },
+            "mkt_medium": { "type": ["string", "null"] },
+            "mkt_source": { "type": ["string", "null"] },
+            "mkt_term": { "type": ["string", "null"] },
+            "mkt_content": { "type": ["string", "null"] },
+            "mkt_campaign": { "type": ["string", "null"] },
+            "contexts": { "type": ["string", "null"] },
+            "se_category": { "type": ["string", "null"] },
+            "se_action": { "type": ["string", "null"] },
+            "se_label": { "type": ["string", "null"] },
+            "se_property": { "type": ["string", "null"] },
+            "se_value": { "type": ["string", "null"] },
+            "unstruct_event": { "type": ["string", "null"] },
+            "tr_orderid": { "type": ["string", "null"] },
+            "tr_affiliation": { "type": ["string", "null"] },
+            "tr_total": { "type": ["string", "null"] },
+            "tr_tax": { "type": ["string", "null"] },
+            "tr_shipping": { "type": ["string", "null"] },
+            "tr_city": { "type": ["string", "null"] },
+            "tr_state": { "type": ["string", "null"] },
+            "tr_country": { "type": ["string", "null"] },
+            "ti_orderid": { "type": ["string", "null"] },
+            "ti_sku": { "type": ["string", "null"] },
+            "ti_name": { "type": ["string", "null"] },
+            "ti_category": { "type": ["string", "null"] },
+            "ti_price": { "type": ["string", "null"] },
+            "ti_quantity": { "type": ["integer", "null"] },
+            "pp_xoffset_min": { "type": ["integer", "null"] },
+            "pp_xoffset_max": { "type": ["integer", "null"] },
+            "pp_yoffset_min": { "type": ["integer", "null"] },
+            "pp_yoffset_max": { "type": ["integer", "null"] },
+            "useragent": { "type": ["string", "null"] },
+            "br_name": { "type": ["string", "null"] },
+            "br_family": { "type": ["string", "null"] },
+            "br_version": { "type": ["string", "null"] },
+            "br_type": { "type": ["string", "null"] },
+            "br_renderengine": { "type": ["string", "null"] },
+            "br_lang": { "type": ["string", "null"] },
+            "br_features_pdf": { "type": ["integer", "null"] },
+            "br_features_flash": { "type": ["integer", "null"] },
+            "br_features_java": { "type": ["integer", "null"] },
+            "br_features_director": { "type": ["integer", "null"] },
+            "br_features_quicktime": { "type": ["integer", "null"] },
+            "br_features_realplayer": { "type": ["integer", "null"] },
+            "br_features_windowsmedia": { "type": ["integer", "null"] },
+            "br_features_gears": { "type": ["integer", "null"] },
+            "br_features_silverlight": { "type": ["integer", "null"] },
+            "br_cookies": { "type": ["integer", "null"] },
+            "br_colordepth": { "type": ["string", "null"] },
+            "br_viewwidth": { "type": ["integer", "null"] },
+            "br_viewheight": { "type": ["integer", "null"] },
+            "os_name": { "type": ["string", "null"] },
+            "os_family": { "type": ["string", "null"] },
+            "os_manufacturer": { "type": ["string", "null"] },
+            "os_timezone": { "type": ["string", "null"] },
+            "dvce_type": { "type": ["string", "null"] },
+            "dvce_ismobile": { "type": ["integer", "null"] },
+            "dvce_screenwidth": { "type": ["integer", "null"] },
+            "dvce_screenheight": { "type": ["integer", "null"] },
+            "doc_charset": { "type": ["string", "null"] },
+            "doc_width": { "type": ["integer", "null"] },
+            "doc_height": { "type": ["integer", "null"] },
+            "tr_currency": { "type": ["string", "null"] },
+            "tr_total_base": { "type": ["string", "null"] },
+            "tr_tax_base": { "type": ["string", "null"] },
+            "tr_shipping_base": { "type": ["string", "null"] },
+            "ti_currency": { "type": ["string", "null"] },
+            "ti_price_base": { "type": ["string", "null"] },
+            "base_currency": { "type": ["string", "null"] },
+            "geo_timezone": { "type": ["string", "null"] },
+            "mkt_clickid": { "type": ["string", "null"] },
+            "mkt_network": { "type": ["string", "null"] },
+            "etl_tags": { "type": ["string", "null"] },
+            "dvce_sent_tstamp": { "type": ["string", "null"] },
+            "refr_domain_userid": { "type": ["string", "null"] },
+            "refr_dvce_tstamp": { "type": ["string", "null"] },
+            "derived_contexts": { "type": ["string", "null"] },
+            "domain_sessionid": { "type": ["string", "null"] },
+            "derived_tstamp": { "type": ["string", "null"] },
+            "event_vendor": { "type": ["string", "null"] },
+            "event_name": { "type": ["string", "null"] },
+            "event_format": { "type": ["string", "null"] },
+            "event_version": { "type": ["string", "null"] },
+            "event_fingerprint": { "type": ["string", "null"] },
+            "true_tstamp": { "type": ["string", "null"] }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "processor": {
+      "type": "object",
+      "description": "Information about the piece of software responsible for the creation of enrichment failures",
+      "properties": {
+        "artifact": {
+          "type": "string",
+          "description": "Artifact responsible for the creation of enrichment failures",
+          "maxLength": 512
+        },
+        "version": {
+          "type": "string",
+          "description": "Version of the artifact responsible for the creation of enrichment failures",
+          "pattern": "^(\\d+\\.\\d+\\.\\d+.*)$",
+          "maxLength": 32
+        }
+      },
+      "required": [ "artifact", "version" ],
+      "additionalProperties": false
+    }
+  },
+  "required": [ "failure", "payload", "processor" ],
+  "additionalProperties": false
+}

--- a/schemas/com.snowplowanalytics.snowplow.badrows/loader_iglu_error/jsonschema/2-0-1
+++ b/schemas/com.snowplowanalytics.snowplow.badrows/loader_iglu_error/jsonschema/2-0-1
@@ -1,0 +1,895 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Schema for Iglu related errors which could be during validation or schema lookup",
+  "self": {
+    "vendor": "com.snowplowanalytics.snowplow.badrows",
+    "name": "loader_iglu_error",
+    "format": "jsonschema",
+    "version": "2-0-1"
+  },
+  "type": "object",
+  "properties": {
+    "failure": {
+      "type": "array",
+      "description": "List of failure messages caused by Iglu subsystem",
+      "items": {
+        "anyOf": [
+          {
+            "type": "object",
+            "description": "Supplied JSON did not validate against its schema (or schema was not found) (IgluError)",
+            "properties": {
+              "schemaKey": {
+                "type": "string",
+                "description": "The iglu schema coordinates to validate against"
+              },
+              "error": {
+                "description": "Iglu client error",
+                "anyOf": [
+                  {
+                    "description": "Resolution error - schema could not be found in the specified repositories, defined by ResolutionError in the Iglu Client",
+                    "properties": {
+                      "error": {
+                        "enum": ["ResolutionError"]
+                      },
+                      "lookupHistory": {
+                        "type": "array",
+                        "minItems": 1,
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "repostitory": {
+                              "type": "string",
+                              "description": "Name of the repostitory as written in resolver.json"
+                            },
+                            "errors": {
+                              "description": "Set of errors which happened for this repository",
+                              "type": "array",
+                              "minItems": 1,
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "error": {
+                                    "description": "Type of error (NotFound does not contain a message)",
+                                    "enum": ["RepoFailure", "ClientFailure", "NotFound"]
+                                  },
+                                  "message": {
+                                    "description": "Optional message in case of ClientFailure or RepoFailure",
+                                    "type": "string",
+                                    "maxLength": 256
+                                  }
+                                },
+                                "required": ["error" ]
+                              }
+                            },
+                            "attempts": {
+                              "type": "integer",
+                              "minimum": 0,
+                              "description": "Number of attempts which have been made"
+                            },
+                            "lastAttempt": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "Timestamp of a last attempt being made"
+                            }
+                          },
+                          "required": ["repository", "errors", "attempts", "lastAttempt"]
+                        }
+                      }
+                    },
+                    "required": [ "error", "lookupHistory" ],
+                    "additionalProperties": false
+                  },
+                  {
+                    "description": "Data is invalid against resolved schema",
+                    "properties": {
+                      "error": {
+                        "enum": ["ValidationError"]
+                      },
+                      "supersededBy": {
+                        "type": ["string", "null"],
+                        "description": "Superseding schema version if original schema is superseded by another schema",
+                        "maxLength": 32
+                      },
+                      "dataReports": {
+                        "type": "array",
+                        "minItems": 1,
+                        "items": {
+                          "properties": {
+                            "message": {
+                              "type": "string",
+                              "description": "Human-readable message describing the issue with the schema"
+                            },
+                            "path": {
+                              "type": ["string", "null"],
+                              "description": "JSON Path to an issue in the faulty JSON datum"
+                            },
+                            "keyword": {
+                              "type": ["string", "null"],
+                              "description": "JSON Schema Keywrod caused invalidation"
+                            },
+                            "targets": {
+                              "type": ["array", "null"]
+                            }
+                          },
+                          "required": [ "path", "message", "keyword", "targets" ],
+                          "additionalProperties": false
+                        }
+                      }
+                    },
+                    "required": [ "dataReports" ],
+                    "additionalProperties": false
+                  },
+                  {
+                    "description": "Schema is invalid and cannot be used to validate an instance",
+                    "properties": {
+                      "error": {
+                        "enum": ["ValidationError"]
+                      },
+                      "supersededBy": {
+                        "type": ["string", "null"],
+                        "description": "Superseding schema version if original schema is superseded by another schema",
+                        "maxLength": 32
+                      },
+                      "schemaIssues": {
+                        "description": "List of problems in resolved JSON schema",
+                        "type": "array",
+                        "minItems": 1,
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "path": {
+                              "type": "string",
+                              "description": "JSON Path to an issue in the faulty JSON Schema"
+                            },
+                            "message": {
+                              "type": "string",
+                              "description": "Human-readable message describing the issue with the schema"
+                            }
+                          },
+                          "required": [ "path", "message" ],
+                          "additionalProperties": false
+                        }
+                      }
+                    },
+                    "required": [ "error" ],
+                    "additionalProperties": false
+                  }
+                ]
+              }
+            },
+            "additionalProperties": false
+          },
+
+          {
+            "type": "object",
+            "description": "JSON returned from a registry couldn't be parsed as a JSON Schema AST (InvalidSchema)",
+            "properties": {
+              "schemaKey": {
+                "description": "Requested schema key",
+                "type": "string"
+              },
+              "message": {
+                "description": "Human-readable message",
+                "type": "string"
+              }
+            },
+            "required": ["schemaKey", "message" ],
+            "additionalProperties": false
+          },
+
+          {
+            "type": "object",
+            "description": "Resolver couldn't resolve a SchemaList (entity for shredding and migration) (SchemaListNotFound)",
+            "properties": {
+              "schemaCriterion": {
+                "type": "string",
+                "description": "Criterion of a list (model-based)"
+              },
+              "error": {
+                "description": "Iglu client error",
+                "anyOf": [
+                  {
+                    "description": "Resolution error - schema could not be found in the specified repositories, defined by ResolutionError in the Iglu Client",
+                    "properties": {
+                      "error": {
+                        "enum": ["ResolutionError"]
+                      },
+                      "lookupHistory": {
+                        "type": "array",
+                        "minItems": 1,
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "repostitory": {
+                              "type": "string",
+                              "description": "Name of the repostitory as written in resolver.json"
+                            },
+                            "errors": {
+                              "description": "Set of errors which happened for this repository",
+                              "type": "array",
+                              "minItems": 1,
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "error": {
+                                    "description": "Type of error (NotFound does not contain a message)",
+                                    "enum": ["RepoFailure", "ClientFailure", "NotFound"]
+                                  },
+                                  "message": {
+                                    "description": "Optional message in case of ClientFailure or RepoFailure",
+                                    "type": "string",
+                                    "maxLength": 256
+                                  }
+                                },
+                                "required": ["error" ]
+                              }
+                            },
+                            "attempts": {
+                              "type": "integer",
+                              "minimum": 0,
+                              "description": "Number of attempts which have been made"
+                            },
+                            "lastAttempt": {
+                              "type": "string",
+                              "format": "date-time",
+                              "description": "Timestamp of a last attempt being made"
+                            }
+                          },
+                          "required": ["repository", "errors", "attempts", "lastAttempt"]
+                        }
+                      }
+                    },
+                    "required": [ "error", "lookupHistory" ],
+                    "additionalProperties": false
+                  },
+                  {
+                    "description": "Data is invalid against resolved schema",
+                    "properties": {
+                      "error": {
+                        "enum": ["ValidationError"]
+                      },
+                      "supersededBy": {
+                        "type": ["string", "null"],
+                        "description": "Superseding schema version if original schema is superseded by another schema",
+                        "maxLength": 32
+                      },
+                      "dataReports": {
+                        "type": "array",
+                        "minItems": 1,
+                        "items": {
+                          "properties": {
+                            "message": {
+                              "type": "string",
+                              "description": "Human-readable message describing the issue with the schema"
+                            },
+                            "path": {
+                              "type": ["string", "null"],
+                              "description": "JSON Path to an issue in the faulty JSON datum"
+                            },
+                            "keyword": {
+                              "type": ["string", "null"],
+                              "description": "JSON Schema Keywrod caused invalidation"
+                            },
+                            "targets": {
+                              "type": ["array", "null"]
+                            }
+                          },
+                          "required": [ "path", "message", "keyword", "targets" ],
+                          "additionalProperties": false
+                        }
+                      }
+                    },
+                    "required": [ "dataReports" ],
+                    "additionalProperties": false
+                  },
+                  {
+                    "description": "Schema is invalid and cannot be used to validate an instance",
+                    "properties": {
+                      "error": {
+                        "enum": ["ValidationError"]
+                      },
+                      "supersededBy": {
+                        "type": ["string", "null"],
+                        "description": "Superseding schema version if original schema is superseded by another schema",
+                        "maxLength": 32
+                      },
+                      "schemaIssues": {
+                        "description": "List of problems in resolved JSON schema",
+                        "type": "array",
+                        "minItems": 1,
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "path": {
+                              "type": "string",
+                              "description": "JSON Path to an issue in the faulty JSON Schema"
+                            },
+                            "message": {
+                              "type": "string",
+                              "description": "Human-readable message describing the issue with the schema"
+                            }
+                          },
+                          "required": [ "path", "message" ],
+                          "additionalProperties": false
+                        }
+                      }
+                    },
+                    "required": [ "error" ],
+                    "additionalProperties": false
+                  }
+                ]
+              }
+            },
+            "required": ["schemaCriterion", "error" ],
+            "additionalProperties": false
+          },
+
+          {
+            "type": "object",
+            "description": "JSON type mismatch against schema (WrongType)",
+            "properties": {
+              "schemaKey": {
+                "description": "Supplied schema key",
+                "type": "string"
+              },
+              "value": {
+                "description": "Supplied JSON value"
+              },
+              "expected": {
+                "type": "string",
+                "description": "Expected type (either machine or human-readable)"
+              }
+            },
+            "required": [ "schemaKey", "value", "expected" ],
+            "additionalProperties": false
+          },
+
+          {
+            "type": "object",
+            "description": "Value expected to be repeatable (NotAnArray)",
+            "properties": {
+              "schemaKey": {
+                "description": "Supplied schema key",
+                "type": "string"
+              },
+              "value": {
+                "description": "Supplied JSON value"
+              },
+              "expected": {
+                "type": "string",
+                "description": "Expected type (either machine or human-readable)"
+              }
+            },
+            "required": [ "schemaKey", "value", "expected" ],
+            "additionalProperties": false
+          },
+
+          {
+            "type": "object",
+            "description": "Key is required by schema, but missing in a value (MissingInValue)",
+            "properties": {
+              "schemaKey": {
+                "description": "Supplied schema key",
+                "type": "string"
+              },
+              "key": {
+                "description": "Expected key"
+              },
+              "value": {
+                "description": "Provided JSON value"
+              }
+            },
+            "required": [ "schemaKey", "key", "value" ],
+            "additionalProperties": false
+          }
+        ]
+      }
+    },
+    "payload": {
+      "type": "object",
+      "description": "The enriched event that resulted in a storage loader failure",
+      "properties": {
+        "app_id": {
+          "type": ["string", "null"],
+          "maxLength": 255
+        },
+        "platform": {
+          "type": ["string", "null"],
+          "maxLength": 255
+        },
+        "etl_tstamp": {
+          "type": ["string", "null"],
+          "format": "date-time"
+        },
+        "collector_tstamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "dvce_created_tstamp": {
+          "type": ["string", "null"],
+          "format": "date-time"
+        },
+        "event": {
+          "type": ["string", "null"],
+          "maxLength": 128
+        },
+        "event_id": {
+          "type": "string",
+          "maxLength": 36
+        },
+        "txn_id": {
+          "type": ["integer", "null"]
+        },
+        "name_tracker": {
+          "type": ["string", "null"],
+          "maxLength": 128
+        },
+        "v_tracker": {
+          "type": ["string", "null"],
+          "maxLength": 100
+        },
+        "v_collector": {
+          "type": "string",
+          "maxLength": 100
+        },
+        "v_etl": {
+          "type": "string",
+          "maxLength": 100
+        },
+        "user_id": {
+          "type": ["string", "null"],
+          "maxLength": 255
+        },
+        "user_ipaddress": {
+          "type": ["string", "null"],
+          "maxLength": 128
+        },
+        "user_fingerprint": {
+          "type": ["string", "null"],
+          "maxLength": 128
+        },
+        "domain_userid": {
+          "type": ["string", "null"],
+          "maxLength": 128
+        },
+        "domain_sessionidx": {
+          "type": ["integer", "null"]
+        },
+        "network_userid": {
+          "type": ["string", "null"],
+          "maxLength": 128
+        },
+        "geo_country": {
+          "type": ["string", "null"],
+          "maxLength": 2
+        },
+        "geo_region": {
+          "type": ["string", "null"],
+          "maxLength": 3
+        },
+        "geo_city": {
+          "type": ["string", "null"],
+          "maxLength": 75
+        },
+        "geo_zipcode": {
+          "type": ["string", "null"],
+          "maxLength": 15
+        },
+        "geo_latitude": {
+          "type": ["number", "null"]
+        },
+        "geo_longitude": {
+          "type": ["number", "null"]
+        },
+        "geo_region_name": {
+          "type": ["string", "null"],
+          "maxLength": 100
+        },
+        "ip_isp": {
+          "type": ["string", "null"],
+          "maxLength": 100
+        },
+        "ip_organization": {
+          "type": ["string", "null"],
+          "maxLength": 128
+        },
+        "ip_domain": {
+          "type": ["string", "null"],
+          "maxLength": 128
+        },
+        "ip_netspeed": {
+          "type": ["string", "null"],
+          "maxLength": 100
+        },
+        "page_url": {
+          "type": ["string", "null"],
+          "maxLength": 4096
+        },
+        "page_title": {
+          "type": ["string", "null"],
+          "maxLength": 2000
+        },
+        "page_referrer": {
+          "type": ["string", "null"],
+          "maxLength": 4096
+        },
+        "page_urlscheme": {
+          "type": ["string", "null"],
+          "maxLength": 16
+        },
+        "page_urlhost": {
+          "type": ["string", "null"],
+          "maxLength": 255
+        },
+        "page_urlport": {
+          "type": ["integer", "null"]
+        },
+        "page_urlpath": {
+          "type": ["string", "null"],
+          "maxLength": 3000
+        },
+        "page_urlquery": {
+          "type": ["string", "null"],
+          "maxLength": 6000
+        },
+        "page_urlfragment": {
+          "type": ["string", "null"],
+          "maxLength": 3000
+        },
+        "refr_urlscheme": {
+          "type": ["string", "null"],
+          "maxLength": 16
+        },
+        "refr_urlhost": {
+          "type": ["string", "null"],
+          "maxLength": 255
+        },
+        "refr_urlport": {
+          "type": ["integer", "null"]
+        },
+        "refr_urlpath": {
+          "type": ["string", "null"],
+          "maxLength": 6000
+        },
+        "refr_urlquery": {
+          "type": ["string", "null"],
+          "maxLength": 6000
+        },
+        "refr_urlfragment": {
+          "type": ["string", "null"],
+          "maxLength": 3000
+        },
+        "refr_medium": {
+          "type": ["string", "null"],
+          "maxLength": 25
+        },
+        "refr_source": {
+          "type": ["string", "null"],
+          "maxLength": 50
+        },
+        "refr_term": {
+          "type": ["string", "null"],
+          "maxLength": 255
+        },
+        "mkt_medium": {
+          "type": ["string", "null"],
+          "maxLength": 255
+        },
+        "mkt_source": {
+          "type": ["string", "null"],
+          "maxLength": 255
+        },
+        "mkt_term": {
+          "type": ["string", "null"],
+          "maxLength": 255
+        },
+        "mkt_content": {
+          "type": ["string", "null"],
+          "maxLength": 500
+        },
+        "mkt_campaign": {
+          "type": ["string", "null"],
+          "maxLength": 255
+        },
+        "se_category": {
+          "type": ["string", "null"],
+          "maxLength": 1000
+        },
+        "se_action": {
+          "type": ["string", "null"],
+          "maxLength": 1000
+        },
+        "se_label": {
+          "type": ["string", "null"],
+          "maxLength": 1000
+        },
+        "se_property": {
+          "type": ["string", "null"],
+          "maxLength": 1000
+        },
+        "se_value": {
+          "type": ["number", "null"]
+        },
+        "tr_orderid": {
+          "type": ["string", "null"],
+          "maxLength": 255
+        },
+        "tr_affiliation": {
+          "type": ["string", "null"],
+          "maxLength": 255
+        },
+        "tr_total": {
+          "type": ["number", "null"]
+        },
+        "tr_tax": {
+          "type": ["number", "null"]
+        },
+        "tr_shipping": {
+          "type": ["number", "null"]
+        },
+        "tr_city": {
+          "type": ["string", "null"],
+          "maxLength": 255
+        },
+        "tr_state": {
+          "type": ["string", "null"],
+          "maxLength": 255
+        },
+        "tr_country": {
+          "type": ["string", "null"],
+          "maxLength": 255
+        },
+        "ti_orderid": {
+          "type": ["string", "null"],
+          "maxLength": 255
+        },
+        "ti_sku": {
+          "type": ["string", "null"],
+          "maxLength": 255
+        },
+        "ti_name": {
+          "type": ["string", "null"],
+          "maxLength": 255
+        },
+        "ti_category": {
+          "type": ["string", "null"],
+          "maxLength": 255
+        },
+        "ti_price": {
+          "type": ["number", "null"]
+        },
+        "ti_quantity": {
+          "type": ["integer", "null"]
+        },
+        "pp_xoffset_min": {
+          "type": ["integer", "null"]
+        },
+        "pp_xoffset_max": {
+          "type": ["integer", "null"]
+        },
+        "pp_yoffset_min": {
+          "type": ["integer", "null"]
+        },
+        "pp_yoffset_max": {
+          "type": ["integer", "null"]
+        },
+        "useragent": {
+          "type": ["string", "null"],
+          "maxLength": 1000
+        },
+        "br_name": {
+          "type": ["string", "null"],
+          "maxLength": 50
+        },
+        "br_family": {
+          "type": ["string", "null"],
+          "maxLength": 50
+        },
+        "br_version": {
+          "type": ["string", "null"],
+          "maxLength": 50
+        },
+        "br_type": {
+          "type": ["string", "null"],
+          "maxLength": 50
+        },
+        "br_renderengine": {
+          "type": ["string", "null"],
+          "maxLength": 50
+        },
+        "br_lang": {
+          "type": ["string", "null"],
+          "maxLength": 255
+        },
+        "br_features_pdf": {
+          "type": ["boolean", "null"]
+        },
+        "br_features_flash": {
+          "type": ["boolean", "null"]
+        },
+        "br_features_java": {
+          "type": ["boolean", "null"]
+        },
+        "br_features_director": {
+          "type": ["boolean", "null"]
+        },
+        "br_features_quicktime": {
+          "type": ["boolean", "null"]
+        },
+        "br_features_realplayer": {
+          "type": ["boolean", "null"]
+        },
+        "br_features_windowsmedia": {
+          "type": ["boolean", "null"]
+        },
+        "br_features_gears": {
+          "type": ["boolean", "null"]
+        },
+        "br_features_silverlight": {
+          "type": ["boolean", "null"]
+        },
+        "br_cookies": {
+          "type": ["boolean", "null"]
+        },
+        "br_colordepth": {
+          "type": ["string", "null"],
+          "maxLength": 12
+        },
+        "br_viewwidth": {
+          "type": ["integer", "null"]
+        },
+        "br_viewheight": {
+          "type": ["integer", "null"]
+        },
+        "os_name": {
+          "type": ["string", "null"],
+          "maxLength": 50
+        },
+        "os_family": {
+          "type": ["string", "null"],
+          "maxLength": 50
+        },
+        "os_manufacturer": {
+          "type": ["string", "null"],
+          "maxLength": 50
+        },
+        "os_timezone": {
+          "type": ["string", "null"],
+          "maxLength": 255
+        },
+        "dvce_type": {
+          "type": ["string", "null"],
+          "maxLength": 50
+        },
+        "dvce_ismobile": {
+          "type": ["boolean", "null"]
+        },
+        "dvce_screenwidth": {
+          "type": ["integer", "null"]
+        },
+        "dvce_screenheight": {
+          "type": ["integer", "null"]
+        },
+        "doc_charset": {
+          "type": ["string", "null"],
+          "maxLength": 128
+        },
+        "doc_width": {
+          "type": ["integer", "null"]
+        },
+        "doc_height": {
+          "type": ["integer", "null"]
+        },
+        "tr_currency": {
+          "type": ["string", "null"],
+          "maxLength": 3
+        },
+        "tr_total_base": {
+          "type": ["number", "null"]
+        },
+        "tr_tax_base": {
+          "type": ["number", "null"]
+        },
+        "tr_shipping_base": {
+          "type": ["number", "null"]
+        },
+        "ti_currency": {
+          "type": ["string", "null"],
+          "maxLength": 3
+        },
+        "ti_price_base": {
+          "type": ["number", "null"]
+        },
+        "base_currency": {
+          "type": ["string", "null"],
+          "maxLength": 3
+        },
+        "geo_timezone": {
+          "type": ["string", "null"],
+          "maxLength": 64
+        },
+        "mkt_clickid": {
+          "type": ["string", "null"],
+          "maxLength": 128
+        },
+        "mkt_network": {
+          "type": ["string", "null"],
+          "maxLength": 64
+        },
+        "etl_tags": {
+          "type": ["string", "null"],
+          "maxLength": 500
+        },
+        "dvce_sent_tstamp": {
+          "type": ["string", "null"],
+          "format": "date-time"
+        },
+        "refr_domain_userid": {
+          "type": ["string", "null"],
+          "maxLength": 128
+        },
+        "refr_dvce_tstamp": {
+          "type": ["string", "null"],
+          "format": "date-time"
+        },
+        "domain_sessionid": {
+          "type": ["string", "null"],
+          "maxLength": 128
+        },
+        "derived_tstamp": {
+          "type": ["string", "null"],
+          "format": "date-time"
+        },
+        "event_vendor": {
+          "type": ["string", "null"],
+          "maxLength": 1000
+        },
+        "event_name": {
+          "type": ["string", "null"],
+          "maxLength": 1000
+        },
+        "event_format": {
+          "type": ["string", "null"],
+          "maxLength": 128
+        },
+        "event_version": {
+          "type": ["string", "null"],
+          "maxLength": 128
+        },
+        "event_fingerprint": {
+          "type": ["string", "null"],
+          "maxLength": 128
+        },
+        "true_tstamp": {
+          "type": ["string", "null"],
+          "format": "date-time"
+        },
+        "unstruct_event": { "type": ["object", "null"] },
+        "contexts": { "type": ["object", "null" ]},
+        "derived_contexts": { "type": ["object", "null" ]}
+      },
+      "additionalProperties": false
+    },
+    "processor": {
+      "type": "object",
+      "description": "Information about the piece of software responsible for the creation of enrichment failures",
+      "properties": {
+        "artifact": {
+          "type": "string",
+          "description": "Artifact responsible for the creation of enrichment failures",
+          "maxLength": 512
+        },
+        "version": {
+          "type": "string",
+          "description": "Version of the artifact responsible for the creation of enrichment failures",
+          "pattern": "^(\\d+\\.\\d+\\.\\d+.*)$",
+          "maxLength": 32
+        }
+      },
+      "required": [ "artifact", "version" ],
+      "additionalProperties": false
+    }
+  },
+  "required": ["failure", "payload", "processor" ],
+  "additionalProperties": false
+}

--- a/schemas/com.snowplowanalytics.snowplow.badrows/recovery_error/jsonschema/1-0-1
+++ b/schemas/com.snowplowanalytics.snowplow.badrows/recovery_error/jsonschema/1-0-1
@@ -1,0 +1,128 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Schema for errors reported by Snowplow Event Recovery",
+  "self": {
+    "vendor": "com.snowplowanalytics.snowplow.badrows",
+    "name": "recovery_error",
+    "format": "jsonschema",
+    "version": "1-0-1"
+  },
+  "type": "object",
+  "properties": {
+    "payload": {
+      "type": "object",
+      "properties": {
+        "schema": {
+          "type": "string",
+          "enum": [
+            "iglu:com.snowplowanalytics.snowplow.badrows/adapter_failures/jsonschema/1-0-0",
+            "iglu:com.snowplowanalytics.snowplow.badrows/collector_payload_format_violation/jsonschema/1-0-0",
+            "iglu:com.snowplowanalytics.snowplow.badrows/enrichment_failures/jsonschema/1-0-0",
+            "iglu:com.snowplowanalytics.snowplow.badrows/enrichment_failures/jsonschema/2-0-0",
+            "iglu:com.snowplowanalytics.snowplow.badrows/enrichment_failures/jsonschema/2-0-1",
+            "iglu:com.snowplowanalytics.snowplow.badrows/loader_iglu_error/jsonschema/2-0-0",
+            "iglu:com.snowplowanalytics.snowplow.badrows/loader_iglu_error/jsonschema/2-0-1",
+            "iglu:com.snowplowanalytics.snowplow.badrows/loader_parsing_error/jsonschema/2-0-0",
+            "iglu:com.snowplowanalytics.snowplow.badrows/loader_recovery_error/jsonschema/1-0-0",
+            "iglu:com.snowplowanalytics.snowplow.badrows/loader_runtime_error/jsonschema/1-0-0",
+            "iglu:com.snowplowanalytics.snowplow.badrows/loader_runtime_error/jsonschema/1-0-1",
+            "iglu:com.snowplowanalytics.snowplow.badrows/relay_failure/jsonschema/1-0-0",
+            "iglu:com.snowplowanalytics.snowplow.badrows/schema_violations/jsonschema/1-0-0",
+            "iglu:com.snowplowanalytics.snowplow.badrows/schema_violations/jsonschema/2-0-0",
+            "iglu:com.snowplowanalytics.snowplow.badrows/schema_violations/jsonschema/2-0-1",
+            "iglu:com.snowplowanalytics.snowplow.badrows/size_violation/jsonschema/1-0-0",
+            "iglu:com.snowplowanalytics.snowplow.badrows/snowflake_error/jsonschema/1-0-0",
+            "iglu:com.snowplowanalytics.snowplow.badrows/tracker_protocol_violations/jsonschema/1-0-0",
+            "iglu:com.snowplowanalytics.snowplow.badrows/tracker_protocol_violations/jsonschema/1-0-1"
+          ],
+          "description": "Original bad row schema"
+        },
+        "data": {
+          "type": "object",
+          "properties": {
+            "processor": {
+              "type": "object",
+              "description": "Original application that the bad row comes from"
+            },
+            "failure": {
+              "type": [
+                "object",
+                "array",
+                "string"
+              ],
+              "description": "Original failure reason(s)"
+            },
+            "payload": {
+              "type": [
+                "object",
+                "string"
+              ],
+              "description": "Original payload object, can be a full payload object or a raw payload string"
+            }
+          },
+          "required": [
+            "processor",
+            "failure"
+          ],
+          "description": "Original bad row contents"
+        }
+      },
+      "required": [
+        "schema",
+        "data"
+      ],
+      "description": "Original bad row"
+    },
+    "recoveries": {
+      "type": "integer",
+      "description": "Number of times payload recovery has been tried"
+    },
+    "failure": {
+      "description": "A reason why payload could not be recovered",
+      "properties": {
+        "error": {
+          "description": "Human-readable error",
+          "type": "string"
+        },
+        "configName": {
+          "description": "Name of recovery configuration that failed",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "error"
+      ]
+    },
+    "processor": {
+      "type": "object",
+      "description": "Information about the piece of software responsible for the creation of enrichment failures",
+      "properties": {
+        "artifact": {
+          "type": "string",
+          "description": "Artifact responsible for the creation of enrichment failures",
+          "maxLength": 512
+        },
+        "version": {
+          "type": "string",
+          "description": "Version of the artifact responsible for the creation of enrichment failures",
+          "pattern": "^(\\d+\\.\\d+\\.\\d+.*)$",
+          "maxLength": 32
+        }
+      },
+      "required": [
+        "artifact",
+        "version"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "payload",
+    "failure",
+    "processor"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/com.snowplowanalytics.snowplow.badrows/schema_violations/jsonschema/2-0-1
+++ b/schemas/com.snowplowanalytics.snowplow.badrows/schema_violations/jsonschema/2-0-1
@@ -1,0 +1,486 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Schema for a bad row resulting from schema violations",
+  "self": {
+    "vendor": "com.snowplowanalytics.snowplow.badrows",
+    "name": "schema_violations",
+    "format": "jsonschema",
+    "version": "2-0-1"
+  },
+  "type": "object",
+  "properties": {
+    "failure": {
+      "type": "object",
+      "description": "Information regarding the schema violations",
+      "properties": {
+        "timestamp": {
+          "type": "string",
+          "description": "Timestamp at which the failure occurred",
+          "format": "date-time"
+        },
+        "messages": {
+          "type": "array",
+          "description": "List of failure messages associated with the tracker protocol violations",
+          "items": {
+            "anyOf": [
+              {
+                "type": "object",
+                "description": "String supplied for schema validation was not JSON",
+                "properties": {
+                  "field": {
+                    "type": "string",
+                    "description": "Field which ended up not being json",
+                    "maxLength": 64
+                  },
+                  "value": {
+                    "type": [ "string", "null" ],
+                    "description": "Stringified representation of the value which is not json"
+                  },
+                  "error": {
+                    "type": "string",
+                    "description": "Json parsing issue"
+                  }
+                },
+                "required": ["field", "error" ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "description": "Json supplied for schema validation was not self-describing",
+                "properties": {
+                  "json": {
+                    "description": "Supplied JSON which was not self-describing"
+                  },
+                  "error": {
+                    "type": "string",
+                    "description": "Issue which the json which makes it not self-describing",
+                    "enum": [ "INVALID_SCHEMAVER", "INVALID_IGLUURI", "INVALID_DATA_PAYLOAD", "INVALID_SCHEMA" ]
+                  }
+                },
+                "required": [ "json", "error" ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "description": "Supplied JSON does not match the associated schema criterion",
+                "properties": {
+                  "schemaKey": {
+                    "description": "Supplied schema key",
+                    "type": "string"
+                  },
+                  "schemaCriterion": {
+                    "type": "string",
+                    "description": "The schema criterion which was not respected"
+                  }
+                },
+                "required": [ "schemaKey", "schemaCriterion" ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "description": "Supplied JSON did not validate against its schema (or schema was not found)",
+                "properties": {
+                  "schemaKey": {
+                    "type": "string",
+                    "description": "The iglu schema coordinates to validate against"
+                  },
+                  "error": {
+                    "description": "Iglu client error",
+                    "anyOf": [
+                      {
+                        "description": "Resolution error - schema could not be found in the specified repositories, defined by ResolutionError in the Iglu Client",
+                        "properties": {
+                          "error": {
+                            "enum": ["ResolutionError"]
+                          },
+                          "lookupHistory": {
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "repostitory": {
+                                  "type": "string",
+                                  "description": "Name of the repostitory as written in resolver.json"
+                                },
+                                "errors": {
+                                  "description": "Set of errors which happened for this repository",
+                                  "type": "array",
+                                  "minItems": 1,
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "error": {
+                                        "description": "Type of error (NotFound does not contain a message)",
+                                        "enum": ["RepoFailure", "ClientFailure", "NotFound"]
+                                      },
+                                      "message": {
+                                        "description": "Optional message in case of ClientFailure or RepoFailure",
+                                        "type": "string",
+                                        "maxLength": 256
+                                      }
+                                    },
+                                    "required": ["error" ]
+                                  }
+                                },
+                                "attempts": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "description": "Number of attempts which have been made"
+                                },
+                                "lastAttempt": {
+                                  "type": "string",
+                                  "format": "date-time",
+                                  "description": "Timestamp of a last attempt being made"
+                                }
+                              },
+                              "required": ["repository", "errors", "attempts", "lastAttempt"]
+                            }
+                          }
+                        },
+                        "required": [ "error", "lookupHistory" ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "description": "Data is invalid against resolved schema",
+                        "properties": {
+                          "error": {
+                            "enum": ["ValidationError"]
+                          },
+                          "supersededBy": {
+                            "type": ["string", "null"],
+                            "description": "Superseding schema version if original schema is superseded by another schema",
+                            "maxLength": 32
+                          },
+                          "dataReports": {
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                              "properties": {
+                                "message": {
+                                  "type": "string",
+                                  "description": "Human-readable message describing the issue with the schema"
+                                },
+                                "path": {
+                                  "type": ["string", "null"],
+                                  "description": "JSON Path to an issue in the faulty JSON datum"
+                                },
+                                "keyword": {
+                                  "type": ["string", "null"],
+                                  "description": "JSON Schema Keywrod caused invalidation"
+                                },
+                                "targets": {
+                                  "type": ["array", "null"]
+                                }
+                              },
+                              "required": [ "path", "message", "keyword", "targets" ],
+                              "additionalProperties": false
+                            }
+                          }
+                        },
+                        "required": [ "dataReports" ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "description": "Schema is invalid and cannot be used to validate an instance",
+                        "properties": {
+                          "error": {
+                            "enum": ["ValidationError"]
+                          },
+                          "supersededBy": {
+                            "type": ["string", "null"],
+                            "description": "Superseding schema version if original schema is superseded by another schema",
+                            "maxLength": 32
+                          },
+                          "schemaIssues": {
+                            "description": "List of problems in resolved JSON schema",
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "path": {
+                                  "type": "string",
+                                  "description": "JSON Path to an issue in the faulty JSON Schema"
+                                },
+                                "message": {
+                                  "type": "string",
+                                  "description": "Human-readable message describing the issue with the schema"
+                                }
+                              },
+                              "required": [ "path", "message" ],
+                              "additionalProperties": false
+                            }
+                          }
+                        },
+                        "required": [ "error" ],
+                        "additionalProperties": false
+                      }
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              }
+            ]
+          }
+        }
+      },
+      "required": [ "timestamp", "messages" ],
+      "additionalProperties": false
+    },
+    "payload": {
+      "type": "object",
+      "properties": {
+        "raw": {
+          "type": "object",
+          "description": "The raw event extracted from collector payload",
+          "properties": {
+            "vendor": {
+              "type": "string",
+              "description": "Vendor of the adapter that processed this payload, here com.snowplowanalytics.snowplow",
+              "maxLength": 64
+            },
+            "version": {
+              "type": "string",
+              "description": "Version of the adapter that processed this payload",
+              "maxLength": 16
+            },
+            "parameters": {
+              "type": [ "array", "null" ],
+              "description": "Query string of the collector payload containing this event",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "Name of the querystring parameter",
+                    "maxLength": 512
+                  },
+                  "value": {
+                    "type": [ "string", "null" ],
+                    "description": "Possible value for the querystring parameter",
+                    "maxLength": 512
+                  }
+                },
+                "required": [ "name", "value" ],
+                "additionalProperties": false
+              }
+            },
+            "contentType": {
+              "type": [ "string", "null" ],
+              "description": "Content type of the payload as detected by the collector",
+              "maxLength": 256
+            },
+            "loaderName": {
+              "type": "string",
+              "maxLength": 32
+            },
+            "encoding": {
+              "type": "string",
+              "description": "Encoding of the collector payload",
+              "maxLength": 32
+            },
+            "hostname": {
+              "type": [ "string", "null" ],
+              "description": "Hostname of the payload as detected by the collector",
+              "maxLength": 8192
+            },
+            "timestamp": {
+              "type": ["string", "null"],
+              "description": "Timestamp at which the payload was collected",
+              "format": "date-time"
+            },
+            "ipAddress": {
+              "type": ["string", "null"],
+              "description": "IP address of the payload as detected by the collector",
+              "maxLength": 128
+            },
+            "useragent": {
+              "type": [ "string", "null" ],
+              "description": "User agent of the payload as detected by the collector",
+              "maxLength": 4096
+            },
+            "refererUri": {
+              "type": [ "string", "null" ],
+              "description": "Referer of the payload as detected by the collector",
+              "maxLength": 8192
+            },
+            "headers": {
+              "type": [ "array", "null" ],
+              "description": "List of the headers part of this collector payload",
+              "items": {
+                "type": "string",
+                "maxLength": 8192
+              }
+            },
+            "userId": {
+              "type": [ "string", "null" ],
+              "description": "Network user id associated with this payload",
+              "format": "uuid"
+            }
+          },
+          "required": [ "vendor", "version", "loaderName", "encoding" ],
+          "additionalProperties": false
+        },
+        "enriched": {
+          "description": "The partially enriched event that resulted in schema violations",
+          "properties": {
+            "app_id": { "type": ["string", "null"] },
+            "platform": { "type": ["string", "null"] },
+            "etl_tstamp": { "type": ["string", "null"] },
+            "collector_tstamp": { "type": ["string", "null"] },
+            "dvce_created_tstamp": { "type": ["string", "null"] },
+            "event": { "type": ["string", "null"] },
+            "event_id": { "type": ["string", "null"] },
+            "txn_id": { "type": ["string", "null"] },
+            "name_tracker": { "type": ["string", "null"] },
+            "v_tracker": { "type": ["string", "null"] },
+            "v_collector": { "type": ["string", "null"] },
+            "v_etl": { "type": ["string", "null"] },
+            "user_id": { "type": ["string", "null"] },
+            "user_ipaddress": { "type": ["string", "null"] },
+            "user_fingerprint": { "type": ["string", "null"] },
+            "domain_userid": { "type": ["string", "null"] },
+            "domain_sessionidx": { "type": ["integer", "null"] },
+            "network_userid": { "type": ["string", "null"] },
+            "geo_country": { "type": ["string", "null"] },
+            "geo_region": { "type": ["string", "null"] },
+            "geo_city": { "type": ["string", "null"] },
+            "geo_zipcode": { "type": ["string", "null"] },
+            "geo_latitude": { "type": ["number", "null"] },
+            "geo_longitude": { "type": ["number", "null"] },
+            "geo_region_name": { "type": ["string", "null"] },
+            "ip_isp": { "type": ["string", "null"] },
+            "ip_organization": { "type": ["string", "null"] },
+            "ip_domain": { "type": ["string", "null"] },
+            "ip_netspeed": { "type": ["string", "null"] },
+            "page_url": { "type": ["string", "null"] },
+            "page_title": { "type": ["string", "null"] },
+            "page_referrer": { "type": ["string", "null"] },
+            "page_urlscheme": { "type": ["string", "null"] },
+            "page_urlhost": { "type": ["string", "null"] },
+            "page_urlport": { "type": ["integer", "null"] },
+            "page_urlpath": { "type": ["string", "null"] },
+            "page_urlquery": { "type": ["string", "null"] },
+            "page_urlfragment": { "type": ["string", "null"] },
+            "refr_urlscheme": { "type": ["string", "null"] },
+            "refr_urlhost": { "type": ["string", "null"] },
+            "refr_urlport": { "type": ["integer", "null"] },
+            "refr_urlpath": { "type": ["string", "null"] },
+            "refr_urlquery": { "type": ["string", "null"] },
+            "refr_urlfragment": { "type": ["string", "null"] },
+            "refr_medium": { "type": ["string", "null"] },
+            "refr_source": { "type": ["string", "null"] },
+            "refr_term": { "type": ["string", "null"] },
+            "mkt_medium": { "type": ["string", "null"] },
+            "mkt_source": { "type": ["string", "null"] },
+            "mkt_term": { "type": ["string", "null"] },
+            "mkt_content": { "type": ["string", "null"] },
+            "mkt_campaign": { "type": ["string", "null"] },
+            "contexts": { "type": ["string", "null"] },
+            "se_category": { "type": ["string", "null"] },
+            "se_action": { "type": ["string", "null"] },
+            "se_label": { "type": ["string", "null"] },
+            "se_property": { "type": ["string", "null"] },
+            "se_value": { "type": ["string", "null"] },
+            "unstruct_event": { "type": ["string", "null"] },
+            "tr_orderid": { "type": ["string", "null"] },
+            "tr_affiliation": { "type": ["string", "null"] },
+            "tr_total": { "type": ["string", "null"] },
+            "tr_tax": { "type": ["string", "null"] },
+            "tr_shipping": { "type": ["string", "null"] },
+            "tr_city": { "type": ["string", "null"] },
+            "tr_state": { "type": ["string", "null"] },
+            "tr_country": { "type": ["string", "null"] },
+            "ti_orderid": { "type": ["string", "null"] },
+            "ti_sku": { "type": ["string", "null"] },
+            "ti_name": { "type": ["string", "null"] },
+            "ti_category": { "type": ["string", "null"] },
+            "ti_price": { "type": ["string", "null"] },
+            "ti_quantity": { "type": ["integer", "null"] },
+            "pp_xoffset_min": { "type": ["integer", "null"] },
+            "pp_xoffset_max": { "type": ["integer", "null"] },
+            "pp_yoffset_min": { "type": ["integer", "null"] },
+            "pp_yoffset_max": { "type": ["integer", "null"] },
+            "useragent": { "type": ["string", "null"] },
+            "br_name": { "type": ["string", "null"] },
+            "br_family": { "type": ["string", "null"] },
+            "br_version": { "type": ["string", "null"] },
+            "br_type": { "type": ["string", "null"] },
+            "br_renderengine": { "type": ["string", "null"] },
+            "br_lang": { "type": ["string", "null"] },
+            "br_features_pdf": { "type": ["integer", "null"] },
+            "br_features_flash": { "type": ["integer", "null"] },
+            "br_features_java": { "type": ["integer", "null"] },
+            "br_features_director": { "type": ["integer", "null"] },
+            "br_features_quicktime": { "type": ["integer", "null"] },
+            "br_features_realplayer": { "type": ["integer", "null"] },
+            "br_features_windowsmedia": { "type": ["integer", "null"] },
+            "br_features_gears": { "type": ["integer", "null"] },
+            "br_features_silverlight": { "type": ["integer", "null"] },
+            "br_cookies": { "type": ["integer", "null"] },
+            "br_colordepth": { "type": ["string", "null"] },
+            "br_viewwidth": { "type": ["integer", "null"] },
+            "br_viewheight": { "type": ["integer", "null"] },
+            "os_name": { "type": ["string", "null"] },
+            "os_family": { "type": ["string", "null"] },
+            "os_manufacturer": { "type": ["string", "null"] },
+            "os_timezone": { "type": ["string", "null"] },
+            "dvce_type": { "type": ["string", "null"] },
+            "dvce_ismobile": { "type": ["integer", "null"] },
+            "dvce_screenwidth": { "type": ["integer", "null"] },
+            "dvce_screenheight": { "type": ["integer", "null"] },
+            "doc_charset": { "type": ["string", "null"] },
+            "doc_width": { "type": ["integer", "null"] },
+            "doc_height": { "type": ["integer", "null"] },
+            "tr_currency": { "type": ["string", "null"] },
+            "tr_total_base": { "type": ["string", "null"] },
+            "tr_tax_base": { "type": ["string", "null"] },
+            "tr_shipping_base": { "type": ["string", "null"] },
+            "ti_currency": { "type": ["string", "null"] },
+            "ti_price_base": { "type": ["string", "null"] },
+            "base_currency": { "type": ["string", "null"] },
+            "geo_timezone": { "type": ["string", "null"] },
+            "mkt_clickid": { "type": ["string", "null"] },
+            "mkt_network": { "type": ["string", "null"] },
+            "etl_tags": { "type": ["string", "null"] },
+            "dvce_sent_tstamp": { "type": ["string", "null"] },
+            "refr_domain_userid": { "type": ["string", "null"] },
+            "refr_dvce_tstamp": { "type": ["string", "null"] },
+            "derived_contexts": { "type": ["string", "null"] },
+            "domain_sessionid": { "type": ["string", "null"] },
+            "derived_tstamp": { "type": ["string", "null"] },
+            "event_vendor": { "type": ["string", "null"] },
+            "event_name": { "type": ["string", "null"] },
+            "event_format": { "type": ["string", "null"] },
+            "event_version": { "type": ["string", "null"] },
+            "event_fingerprint": { "type": ["string", "null"] },
+            "true_tstamp": { "type": ["string", "null"] }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "processor": {
+      "type": "object",
+      "description": "Information about the piece of software responsible for the creation of schema violations",
+      "properties": {
+        "artifact": {
+          "type": "string",
+          "description": "Artifact responsible for the creation of schema violations",
+          "maxLength": 512
+        },
+        "version": {
+          "type": "string",
+          "description": "Version of the artifact responsible for the creation of schema violations",
+          "pattern": "^(\\d+\\.\\d+\\.\\d+.*)$",
+          "maxLength": 32
+        }
+      },
+      "required": [ "artifact", "version" ],
+      "additionalProperties": false
+    }
+  },
+  "required": [ "failure", "payload", "processor" ],
+  "additionalProperties": false
+}

--- a/schemas/com.snowplowanalytics.snowplow.badrows/tracker_protocol_violations/jsonschema/1-0-1
+++ b/schemas/com.snowplowanalytics.snowplow.badrows/tracker_protocol_violations/jsonschema/1-0-1
@@ -1,0 +1,383 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Schema for a bad row resulting from tracker protocol violations",
+  "self": {
+    "vendor": "com.snowplowanalytics.snowplow.badrows",
+    "name": "tracker_protocol_violations",
+    "format": "jsonschema",
+    "version": "1-0-1"
+  },
+  "type": "object",
+  "properties": {
+    "failure": {
+      "type": "object",
+      "description": "Information regarding the tracker protocol violations",
+      "properties": {
+        "timestamp": {
+          "type": "string",
+          "description": "Timestamp at which the failure occurred",
+          "format": "date-time"
+        },
+        "vendor": {
+          "type": "string",
+          "description": "Vendor of the adapter that processed this payload, here com.snowplowanalytics.snowplow",
+          "maxLength": 64
+        },
+        "version": {
+          "type": "string",
+          "description": "Version of the adapter that processed this payload, here tp2",
+          "maxLength": 16
+        },
+        "messages": {
+          "type": "array",
+          "description": "List of failure messages associated with the tracker protocol violations",
+          "items": {
+            "anyOf": [
+              {
+                "type": "object",
+                "description": "Error which was internal to the adapter regarding its input data",
+                "properties": {
+                  "field": {
+                    "type": "string",
+                    "description": "Field which did not meet the adapter's expectations",
+                    "maxLength": 64
+                  },
+                  "value": {
+                    "type": [ "string", "null" ],
+                    "description": "Stringified representation of the value which did not meet expectations"
+                  },
+                  "expectation": {
+                    "type": "string",
+                    "description": "Expectation which was not met",
+                    "maxLength": 256
+                  }
+                },
+                "required": [ "field", "expectation" ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "description": "String supplied for schema validation was not JSON",
+                "properties": {
+                  "field": {
+                    "type": "string",
+                    "description": "Field which ended up not being json",
+                    "maxLength": 64
+                  },
+                  "value": {
+                    "type": [ "string", "null" ],
+                    "description": "Stringified representation of the value which is not json"
+                  },
+                  "error": {
+                    "type": "string",
+                    "description": "Json parsing issue"
+                  }
+                },
+                "required": ["field", "error" ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "description": "Json supplied for schema validation was not self-describing",
+                "properties": {
+                  "json": {
+                    "description": "Supplied JSON which was not self-describing"
+                  },
+                  "error": {
+                    "type": "string",
+                    "description": "Issue which the json which makes it not self-describing",
+                    "enum": [ "INVALID_SCHEMAVER", "INVALID_IGLUURI", "INVALID_DATA_PAYLOAD", "INVALID_SCHEMA" ]
+                  }
+                },
+                "required": [ "json", "error" ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "description": "Supplied JSON does not match the associated schema criterion",
+                "properties": {
+                  "schemaKey": {
+                    "description": "Supplied schema key",
+                    "type": "string"
+                  },
+                  "schemaCriterion": {
+                    "type": "string",
+                    "description": "The schema criterion which was not respected"
+                  }
+                },
+                "required": [ "schemaKey", "schemaCriterion" ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "description": "Supplied JSON did not validate against its schema (or schema was not found)",
+                "properties": {
+                  "schemaKey": {
+                    "type": "string",
+                    "description": "The iglu schema coordinates to validate against"
+                  },
+                  "error": {
+                    "description": "Iglu client error",
+                    "anyOf": [
+                      {
+                        "description": "Resolution error - schema could not be found in the specified repositories, defined by ResolutionError in the Iglu Client",
+                        "properties": {
+                          "error": {
+                            "enum": ["ResolutionError"]
+                          },
+                          "lookupHistory": {
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "repostitory": {
+                                  "type": "string",
+                                  "description": "Name of the repostitory as written in resolver.json"
+                                },
+                                "errors": {
+                                  "description": "Set of errors which happened for this repository",
+                                  "type": "array",
+                                  "minItems": 1,
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "error": {
+                                        "description": "Type of error (NotFound does not contain a message)",
+                                        "enum": ["RepoFailure", "ClientFailure", "NotFound"]
+                                      },
+                                      "message": {
+                                        "description": "Optional message in case of ClientFailure or RepoFailure",
+                                        "type": "string",
+                                        "maxLength": 256
+                                      }
+                                    },
+                                    "required": ["error" ]
+                                  }
+                                },
+                                "attempts": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "description": "Number of attempts which have been made"
+                                },
+                                "lastAttempt": {
+                                  "type": "string",
+                                  "format": "date-time",
+                                  "description": "Timestamp of a last attempt being made"
+                                }
+                              },
+                              "required": ["repository", "errors", "attempts", "lastAttempt"]
+                            }
+                          }
+                        },
+                        "required": [ "error", "lookupHistory" ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "description": "Data is invalid against resolved schema",
+                        "properties": {
+                          "error": {
+                            "enum": ["ValidationError"]
+                          },
+                          "supersededBy": {
+                            "type": ["string", "null"],
+                            "description": "Superseding schema version if original schema is superseded by another schema",
+                            "maxLength": 32
+                          },
+                          "dataReports": {
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                              "properties": {
+                                "message": {
+                                  "type": "string",
+                                  "description": "Human-readable message describing the issue with the schema"
+                                },
+                                "path": {
+                                  "type": ["string", "null"],
+                                  "description": "JSON Path to an issue in the faulty JSON datum"
+                                },
+                                "keyword": {
+                                  "type": ["string", "null"],
+                                  "description": "JSON Schema Keywrod caused invalidation"
+                                },
+                                "targets": {
+                                  "type": ["array", "null"]
+                                }
+                              },
+                              "required": [ "path", "message", "keyword", "targets" ],
+                              "additionalProperties": false
+                            }
+                          }
+                        },
+                        "required": [ "dataReports" ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "description": "Schema is invalid and cannot be used to validate an instance",
+                        "properties": {
+                          "error": {
+                            "enum": ["ValidationError"]
+                          },
+                          "supersededBy": {
+                            "type": ["string", "null"],
+                            "description": "Superseding schema version if original schema is superseded by another schema",
+                            "maxLength": 32
+                          },
+                          "schemaIssues": {
+                            "description": "List of problems in resolved JSON schema",
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "path": {
+                                  "type": "string",
+                                  "description": "JSON Path to an issue in the faulty JSON Schema"
+                                },
+                                "message": {
+                                  "type": "string",
+                                  "description": "Human-readable message describing the issue with the schema"
+                                }
+                              },
+                              "required": [ "path", "message" ],
+                              "additionalProperties": false
+                            }
+                          }
+                        },
+                        "required": [ "error" ],
+                        "additionalProperties": false
+                      }
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              }
+            ]
+          }
+        }
+      },
+      "required": [ "timestamp", "vendor", "version", "messages" ],
+      "additionalProperties": false
+    },
+    "payload": {
+      "type": "object",
+      "description": "The collector payload that resulted in tracker protocol violations",
+      "properties": {
+        "vendor": {
+          "type": "string",
+          "description": "Vendor of the adapter that processed this payload, here com.snowplowanalytics.snowplow",
+          "maxLength": 64
+        },
+        "version": {
+          "type": "string",
+          "description": "Version of the adapter that processed this payload, here always 'tp2' (maxLength 16 for compatibility)",
+          "maxLength": 16
+        },
+        "querystring": {
+          "type": [ "array", "null" ],
+          "description": "Query string of this collector payload",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Name of the querystring parameter",
+                "maxLength": 512
+              },
+              "value": {
+                "type": [ "string", "null" ],
+                "description": "Possible value for the querystring parameter",
+                "maxLength": 512
+              }
+            },
+            "required": [ "name" ],
+            "additionalProperties": false
+          }
+        },
+        "contentType": {
+          "type": [ "string", "null" ],
+          "description": "Content type of the payload as detected by the collector",
+          "maxLength": 256
+        },
+        "body": {
+          "type": [ "string", "null" ],
+          "description": "Body of this collector payload"
+        },
+        "collector": {
+          "type": "string",
+          "description": "Collector which produced this collector payload",
+          "maxLength": 32
+        },
+        "encoding": {
+          "type": "string",
+          "description": "Encoding of the collector payload",
+          "maxLength": 32
+        },
+        "hostname": {
+          "type": [ "string", "null" ],
+          "description": "Hostname of the payload as detected by the collector",
+          "maxLength": 8192
+        },
+        "timestamp": {
+          "type": ["string", "null"],
+          "description": "Timestamp at which the payload was collected",
+          "format": "date-time"
+        },
+        "ipAddress": {
+          "type": ["string", "null"],
+          "description": "IP address of the payload as detected by the collector",
+          "maxLength": 128
+        },
+        "useragent": {
+          "type": [ "string", "null" ],
+          "description": "User agent of the payload as detected by the collector",
+          "maxLength": 4096
+        },
+        "refererUri": {
+          "type": [ "string", "null" ],
+          "description": "Referer of the payload as detected by the collector",
+          "maxLength": 8192
+        },
+        "headers": {
+          "type": [ "array", "null" ],
+          "description": "List of the headers part of this collector payload",
+          "items": {
+            "type": "string",
+            "maxLength": 8192
+          }
+        },
+        "networkUserId": {
+          "type": [ "string", "null" ],
+          "description": "Network user id associated with this payload",
+          "format": "uuid"
+        }
+      },
+      "required": [ "vendor", "version", "collector", "encoding" ],
+      "additionalProperties": false
+    },
+    "processor": {
+      "type": "object",
+      "description": "Information about the piece of software responsible for the creation of tracker protocol violations",
+      "properties": {
+        "artifact": {
+          "type": "string",
+          "description": "Artifact responsible for the creation of tracker protocol violations",
+          "maxLength": 512
+        },
+        "version": {
+          "type": "string",
+          "description": "Version of the artifact responsible for the creation of tracker protocol violations",
+          "pattern": "^(\\d+\\.\\d+\\.\\d+.*)$",
+          "maxLength": 32
+        }
+      },
+      "required": [ "artifact", "version" ],
+      "additionalProperties": false
+    }
+  },
+  "required": [ "failure", "payload", "processor" ],
+  "additionalProperties": false
+}
+
+


### PR DESCRIPTION
We are adding [a new feature](https://github.com/snowplow/enrich/issues/751) to Enrich to make it possible supersede schemas.  If a schema is superseded, superseding schema will be used during validation.

If a bad row is created during the validation with superseded schema, we want to attach the superseding schema version to bad rows. For this purpose, we want to add `supersededBy` property to respective bad row schemas.