### PR TITLE
Patch com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0

### DIFF
--- a/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0
@@ -39,7 +39,7 @@
 		},
 
 		{
-			"$ref": "http://json-schema.org/draft-04/schema#"
+			"$ref": "https://json-schema.org/draft-04/schema"
 		}
 	]
 


### PR DESCRIPTION
Details in #1292.
Hopefully this is the best course of action to prevent bad rows being emitted when the schema is being used as a basis for a context.