### PR TITLE
Update schemas for the Sendgrid webhook to fix problems with email, ip and asm_group_id validation (close #1309)

### DIFF
--- a/schemas/com.sendgrid/bounce/jsonschema/3-0-0
+++ b/schemas/com.sendgrid/bounce/jsonschema/3-0-0
@@ -1,0 +1,108 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Schema for a SendGrid bounce event. Property descriptions derived from the SendGrid documentation: https://sendgrid.com/docs/for-developers/tracking-events/event/",
+  "self": {
+    "vendor": "com.sendgrid",
+    "name": "bounce",
+    "version": "3-0-0",
+    "format": "jsonschema"
+  },
+  "type": "object",
+  "properties": {
+    "ip": {
+      "description": "The IP address used to send the email. For open and click events, it is the IP address of the recipient who engaged with the email.",
+      "type": "string",
+      "maxLength": 45
+    },
+    "timestamp": {
+      "description": "The timestamp of when the message was sent",
+      "type": "string",
+      "format": "date-time"
+    },
+    "email": {
+      "description": "The email address of the recipient",
+      "type": "string",
+      "maxLength": 320
+    },
+    "newsletter": {
+      "description": "Legacy Marketing Email tool fields",
+      "type": "object",
+      "properties": {
+        "newsletter_user_list_id": {
+          "type": "string"
+        },
+        "newsletter_id": {
+          "type": "string"
+        },
+        "newsletter_send_id": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": true
+    },
+    "sg_event_id": {
+      "description": "A unique ID to this event that you can use for deduplication purposes. These IDs are up to 100 characters long and are URL safe.",
+      "type": "string",
+      "minLength": 22,
+      "maxLength": 4096
+    },
+    "smtp-id": {
+      "description": "A unique ID attached to the message by the originating system",
+      "type": "string"
+    },
+    "reason": {
+      "description": "Any sort of error response returned by the receiving server that describes the reason this event type was triggered",
+      "type": "string"
+    },
+    "tls": {
+      "description": "Indicates whether TLS encription was used in sending this message. For more information about TLS, see the SendGrid TLS Glossary page.",
+      "type": ["string", "integer"]
+    },
+    "status": {
+      "description": "Status code string. Corresponds to HTTP status code - for example, a JSON response of 5.0.0 is the same as a 500 error response.",
+      "type": "string"
+    },
+    "cert_error": {
+      "description": "No longer found in the SendGrid documentation; possibly deprecated",
+      "type": "string"
+    },
+    "category": {
+      "description": "Categories are custom tags that you set for the purpose of organizing your emails. Categories can be set as an array or string, and they will be returned as such when posted in your event endpoint.",
+      "type": ["array", "string"],
+      "items": {
+        "type": "string"
+      }
+    },
+    "asm_group_id": {
+      "description": "The ID of the unsubscribe group the recipient’s email address is included in. ASM IDs correspond to the ID that is returned when you create an unsubscribe group.",
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 9223372036854775807
+    },
+    "type": {
+      "description": "Type of bounce, eg Bounce/Blocked/Expired",
+      "type": "string"
+    },
+    "sg_message_id": {
+      "description": "A unique, internal SendGrid ID for the message. The first half of this is pulled from the smtp-id.",
+      "type": "string"
+    },
+    "marketing_campaign_id": {
+      "description": "For emails sent through our Marketing Campaigns feature, we add Marketing Campaigns specific parameters to the Event Webhook. Both marketing_campaign_name and marketing_campaign_id are displayed as unique arguments in the event data.",
+      "type": "integer"
+    },
+    "marketing_campaign_name": {
+      "description": "For emails sent through our Marketing Campaigns feature, we add Marketing Campaigns specific parameters to the Event Webhook. Both marketing_campaign_name and marketing_campaign_id are displayed as unique arguments in the event data.",
+      "type": "string"
+    },
+    "marketing_campaign_version": {
+      "description": "Displayed in the event data for emails sent as part of an A/B Test. The value for marketing_campaign_version are returned as A, B, C, etc.",
+      "type": "string"
+    },
+    "marketing_campaign_split_id": {
+      "description": "Marketing campaign split id",
+      "type": "integer"
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/com.sendgrid/click/jsonschema/3-0-0
+++ b/schemas/com.sendgrid/click/jsonschema/3-0-0
@@ -1,0 +1,97 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Schema for a SendGrid clicked event. Property descriptions derived from the SendGrid documentation: https://sendgrid.com/docs/for-developers/tracking-events/event/",
+  "self": {
+    "vendor": "com.sendgrid",
+    "name": "click",
+    "version": "3-0-0",
+    "format": "jsonschema"
+  },
+  "type": "object",
+  "properties": {
+    "ip": {
+      "description": "The IP address used to send the email. For open and click events, it is the IP address of the recipient who engaged with the email.",
+      "type": "string",
+      "maxLength": 45
+    },
+    "timestamp": {
+      "description": "The timestamp of when the message was sent",
+      "type": "string",
+      "format": "date-time"
+    },
+    "email": {
+      "description": "The email address of the recipient",
+      "type": "string",
+      "maxLength": 320
+    },
+    "url": {
+      "description": "The URL where the event originates. For click events, this is the URL clicked on by the recipient.",
+      "type": "string",
+      "format": "uri"
+    },
+    "newsletter": {
+      "description": "Legacy Marketing Email tool fields",
+      "type": "object",
+      "properties": {
+        "newsletter_user_list_id": {
+          "type": "string"
+        },
+        "newsletter_id": {
+          "type": "string"
+        },
+        "newsletter_send_id": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": true
+    },
+    "sg_event_id": {
+      "description": "A unique ID to this event that you can use for deduplication purposes. These IDs are up to 100 characters long and are URL safe.",
+      "type": "string",
+      "minLength": 22,
+      "maxLength": 4096
+    },
+    "smtp-id": {
+      "description": "A unique ID attached to the message by the originating system",
+      "type": "string"
+    },
+    "useragent": {
+      "description": "The user agent responsible for the event. This is usually a web browser. For example, Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.95 Safari/537.36.",
+      "type": "string"
+    },
+    "category": {
+      "description": "Categories are custom tags that you set for the purpose of organizing your emails. Categories can be set as an array or string, and they will be returned as such when posted in your event endpoint.",
+      "type": ["array", "string"],
+      "items": {
+        "type": "string"
+      }
+    },
+    "asm_group_id": {
+      "description": "The ID of the unsubscribe group the recipient’s email address is included in. ASM IDs correspond to the ID that is returned when you create an unsubscribe group.",
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 9223372036854775807
+    },
+    "sg_message_id": {
+      "description": "A unique, internal SendGrid ID for the message. The first half of this is pulled from the smtp-id.",
+      "type": "string"
+    },
+    "marketing_campaign_id": {
+      "description": "For emails sent through our Marketing Campaigns feature, we add Marketing Campaigns specific parameters to the Event Webhook. Both marketing_campaign_name and marketing_campaign_id are displayed as unique arguments in the event data.",
+      "type": "integer"
+    },
+    "marketing_campaign_name": {
+      "description": "For emails sent through our Marketing Campaigns feature, we add Marketing Campaigns specific parameters to the Event Webhook. Both marketing_campaign_name and marketing_campaign_id are displayed as unique arguments in the event data.",
+      "type": "string"
+    },
+    "marketing_campaign_version": {
+      "description": "Displayed in the event data for emails sent as part of an A/B Test. The value for marketing_campaign_version are returned as A, B, C, etc.",
+      "type": "string"
+    },
+    "marketing_campaign_split_id": {
+      "description": "Marketing campaign split id",
+      "type": "integer"
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/com.sendgrid/deferred/jsonschema/3-0-0
+++ b/schemas/com.sendgrid/deferred/jsonschema/3-0-0
@@ -1,0 +1,104 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Schema for a SendGrid deferred event. Property descriptions derived from the SendGrid documentation: https://sendgrid.com/docs/for-developers/tracking-events/event/",
+  "self": {
+    "vendor": "com.sendgrid",
+    "name": "deferred",
+    "version": "3-0-0",
+    "format": "jsonschema"
+  },
+  "type": "object",
+  "properties": {
+    "ip": {
+      "description": "The IP address used to send the email",
+      "type": "string",
+      "maxLength": 45
+    },
+    "timestamp": {
+      "description": "The timestamp of when the message was sent",
+      "type": "string",
+      "format": "date-time"
+    },
+    "email": {
+      "description": "The email address of the recipient",
+      "type": "string",
+      "maxLength": 320
+    },
+    "newsletter": {
+      "description": "Legacy Marketing Email tool fields",
+      "type": "object",
+      "properties": {
+        "newsletter_user_list_id": {
+          "type": "string"
+        },
+        "newsletter_id": {
+          "type": "string"
+        },
+        "newsletter_send_id": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": true
+    },
+    "sg_event_id": {
+      "description": "A unique ID to this event that you can use for deduplication purposes. These IDs are up to 100 characters long and are URL safe.",
+      "type": "string",
+      "minLength": 22,
+      "maxLength": 4096
+    },
+    "smtp-id": {
+      "description": "A unique ID attached to the message by the originating system",
+      "type": "string"
+    },
+    "tls": {
+      "description": "Indicates whether TLS encription was used in sending this message. For more information about TLS, see the SendGrid TLS Glossary page.",
+      "type": ["string", "integer"]
+    },
+    "response": {
+      "description": "The full text of the HTTP response error returned from the receiving server",
+      "type": "string"
+    },
+    "cert_error": {
+      "description": "No longer found in the SendGrid documentation; possibly deprecated",
+      "type": "string"
+    },
+    "category": {
+      "description": "Categories are custom tags that you set for the purpose of organizing your emails. Categories can be set as an array or string, and they will be returned as such when posted in your event endpoint.",
+      "type": ["array", "string"],
+      "items": {
+        "type": "string"
+      }
+    },
+    "asm_group_id": {
+      "description": "The ID of the unsubscribe group the recipient’s email address is included in. ASM IDs correspond to the ID that is returned when you create an unsubscribe group.",
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 9223372036854775807
+    },
+    "attempt": {
+      "description": "The number of times SendGrid has attempted to deliver this message",
+      "type": "string"
+    },
+    "sg_message_id": {
+      "description": "A unique, internal SendGrid ID for the message. The first half of this is pulled from the smtp-id.",
+      "type": "string"
+    },
+    "marketing_campaign_id": {
+      "description": "For emails sent through our Marketing Campaigns feature, we add Marketing Campaigns specific parameters to the Event Webhook. Both marketing_campaign_name and marketing_campaign_id are displayed as unique arguments in the event data.",
+      "type": "integer"
+    },
+    "marketing_campaign_name": {
+      "description": "For emails sent through our Marketing Campaigns feature, we add Marketing Campaigns specific parameters to the Event Webhook. Both marketing_campaign_name and marketing_campaign_id are displayed as unique arguments in the event data.",
+      "type": "string"
+    },
+    "marketing_campaign_version": {
+      "description": "Displayed in the event data for emails sent as part of an A/B Test. The value for marketing_campaign_version are returned as A, B, C, etc.",
+      "type": "string"
+    },
+    "marketing_campaign_split_id": {
+      "description": "Marketing campaign split id",
+      "type": "integer"
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/com.sendgrid/delivered/jsonschema/3-0-0
+++ b/schemas/com.sendgrid/delivered/jsonschema/3-0-0
@@ -1,0 +1,100 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Schema for a SendGrid delivered event. Property descriptions derived from the SendGrid documentation: https://sendgrid.com/docs/for-developers/tracking-events/event/",
+  "self": {
+    "vendor": "com.sendgrid",
+    "name": "delivered",
+    "version": "3-0-0",
+    "format": "jsonschema"
+  },
+  "type": "object",
+  "properties": {
+    "ip": {
+      "description": "The IP address used to send the email",
+      "type": "string",
+      "maxLength": 45
+    },
+    "timestamp": {
+      "description": "The timestamp of when the message was sent",
+      "type": "string",
+      "format": "date-time"
+    },
+    "email": {
+      "description": "The email address of the recipient",
+      "type": "string",
+      "maxLength": 320
+    },
+    "newsletter": {
+      "description": "Legacy Marketing Email tool fields",
+      "type": "object",
+      "properties": {
+        "newsletter_user_list_id": {
+          "type": "string"
+        },
+        "newsletter_id": {
+          "type": "string"
+        },
+        "newsletter_send_id": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": true
+    },
+    "sg_event_id": {
+      "description": "A unique ID to this event that you can use for deduplication purposes. These IDs are up to 100 characters long and are URL safe.",
+      "type": "string",
+      "minLength": 22,
+      "maxLength": 4096
+    },
+    "smtp-id": {
+      "description": "A unique ID attached to the message by the originating system",
+      "type": "string"
+    },
+    "tls": {
+      "description": "Indicates whether TLS encription was used in sending this message. For more information about TLS, see the SendGrid TLS Glossary page.",
+      "type": ["string", "integer"]
+    },
+    "response": {
+      "description": "The full text of the HTTP response error returned from the receiving server",
+      "type": "string"
+    },
+    "cert_error": {
+      "description": "No longer found in the SendGrid documentation; possibly deprecated",
+      "type": "string"
+    },
+    "category": {
+      "description": "Categories are custom tags that you set for the purpose of organizing your emails. Categories can be set as an array or string, and they will be returned as such when posted in your event endpoint.",
+      "type": ["array", "string"],
+      "items": {
+        "type": "string"
+      }
+    },
+    "asm_group_id": {
+      "description": "The ID of the unsubscribe group the recipient’s email address is included in. ASM IDs correspond to the ID that is returned when you create an unsubscribe group.",
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 9223372036854775807
+    },
+    "sg_message_id": {
+      "description": "A unique, internal SendGrid ID for the message. The first half of this is pulled from the smtp-id.",
+      "type": "string"
+    },
+    "marketing_campaign_id": {
+      "description": "For emails sent through our Marketing Campaigns feature, we add Marketing Campaigns specific parameters to the Event Webhook. Both marketing_campaign_name and marketing_campaign_id are displayed as unique arguments in the event data.",
+      "type": "integer"
+    },
+    "marketing_campaign_name": {
+      "description": "For emails sent through our Marketing Campaigns feature, we add Marketing Campaigns specific parameters to the Event Webhook. Both marketing_campaign_name and marketing_campaign_id are displayed as unique arguments in the event data.",
+      "type": "string"
+    },
+    "marketing_campaign_version": {
+      "description": "Displayed in the event data for emails sent as part of an A/B Test. The value for marketing_campaign_version are returned as A, B, C, etc.",
+      "type": "string"
+    },
+    "marketing_campaign_split_id": {
+      "description": "Marketing campaign split id",
+      "type": "integer"
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/com.sendgrid/dropped/jsonschema/3-0-0
+++ b/schemas/com.sendgrid/dropped/jsonschema/3-0-0
@@ -1,0 +1,69 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Schema for a SendGrid dropped event. Property descriptions derived from the SendGrid documentation: https://sendgrid.com/docs/for-developers/tracking-events/event/",
+  "self": {
+    "vendor": "com.sendgrid",
+    "name": "dropped",
+    "version": "3-0-0",
+    "format": "jsonschema"
+  },
+  "type": "object",
+  "properties": {
+    "timestamp": {
+      "description": "The timestamp of when the message was sent",
+      "type": "string",
+      "format": "date-time"
+    },
+    "email": {
+      "description": "The email address of the recipient",
+      "type": "string",
+      "maxLength": 320
+    },
+    "sg_event_id": {
+      "description": "A unique ID to this event that you can use for deduplication purposes. These IDs are up to 100 characters long and are URL safe.",
+      "type": "string",
+      "minLength": 22,
+      "maxLength": 4096
+    },
+    "smtp-id": {
+      "description": "A unique ID attached to the message by the originating system",
+      "type": "string"
+    },
+    "reason": {
+      "description": "Any sort of error response returned by the receiving server that describes the reason this event type was triggered",
+      "type": "string"
+    },
+    "status": {
+      "description": "Status code string. Corresponds to HTTP status code - for example, a JSON response of 5.0.0 is the same as a 500 error response.",
+      "type": "string"
+    },
+    "category": {
+      "description": "Categories are custom tags that you set for the purpose of organizing your emails. Categories can be set as an array or string, and they will be returned as such when posted in your event endpoint.",
+      "type": ["array", "string"],
+      "items": {
+        "type": "string"
+      }
+    },
+    "sg_message_id": {
+      "description": "A unique, internal SendGrid ID for the message. The first half of this is pulled from the smtp-id.",
+      "type": "string"
+    },
+    "marketing_campaign_id": {
+      "description": "For emails sent through our Marketing Campaigns feature, we add Marketing Campaigns specific parameters to the Event Webhook. Both marketing_campaign_name and marketing_campaign_id are displayed as unique arguments in the event data.",
+      "type": "integer"
+    },
+    "marketing_campaign_name": {
+      "description": "For emails sent through our Marketing Campaigns feature, we add Marketing Campaigns specific parameters to the Event Webhook. Both marketing_campaign_name and marketing_campaign_id are displayed as unique arguments in the event data.",
+      "type": "string"
+    },
+    "marketing_campaign_version": {
+      "description": "Displayed in the event data for emails sent as part of an A/B Test. The value for marketing_campaign_version are returned as A, B, C, etc.",
+      "type": "string"
+    },
+    "marketing_campaign_split_id": {
+      "description": "Marketing campaign split id",
+      "type": "integer"
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/com.sendgrid/group_resubscribe/jsonschema/3-0-0
+++ b/schemas/com.sendgrid/group_resubscribe/jsonschema/3-0-0
@@ -1,0 +1,81 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Schema for a SendGrid group resubscribe event. Property descriptions derived from the SendGrid documentation: https://sendgrid.com/docs/for-developers/tracking-events/event/",
+  "self": {
+    "vendor": "com.sendgrid",
+    "name": "group_resubscribe",
+    "version": "3-0-0",
+    "format": "jsonschema"
+  },
+  "type": "object",
+  "properties": {
+    "ip": {
+      "description": "The IP address used to send the email. For open and click events, it is the IP address of the recipient who engaged with the email.",
+      "type": "string",
+      "maxLength": 45
+    },
+    "timestamp": {
+      "description": "The timestamp of when the message was sent",
+      "type": "string",
+      "format": "date-time"
+    },
+    "email": {
+      "description": "The email address of the recipient",
+      "type": "string",
+      "maxLength": 320
+    },
+    "url": {
+      "description": "The URL where the event originates. For click events, this is the URL clicked on by the recipient.",
+      "type": "string",
+      "format": "uri"
+    },
+    "sg_event_id": {
+      "description": "A unique ID to this event that you can use for deduplication purposes. These IDs are up to 100 characters long and are URL safe.",
+      "type": "string",
+      "minLength": 22,
+      "maxLength": 4096
+    },
+    "smtp-id": {
+      "description": "A unique ID attached to the message by the originating system",
+      "type": "string"
+    },
+    "useragent": {
+      "description": "The user agent responsible for the event. This is usually a web browser. For example, Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.95 Safari/537.36.",
+      "type": "string"
+    },
+    "category": {
+      "description": "Categories are custom tags that you set for the purpose of organizing your emails. Categories can be set as an array or string, and they will be returned as such when posted in your event endpoint.",
+      "type": ["array", "string"],
+      "items": {
+        "type": "string"
+      }
+    },
+    "asm_group_id": {
+      "description": "The ID of the unsubscribe group the recipient’s email address is included in. ASM IDs correspond to the ID that is returned when you create an unsubscribe group.",
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 9223372036854775807
+    },
+    "sg_message_id": {
+      "description": "A unique, internal SendGrid ID for the message. The first half of this is pulled from the smtp-id.",
+      "type": "string"
+    },
+    "marketing_campaign_id": {
+      "description": "For emails sent through our Marketing Campaigns feature, we add Marketing Campaigns specific parameters to the Event Webhook. Both marketing_campaign_name and marketing_campaign_id are displayed as unique arguments in the event data.",
+      "type": "integer"
+    },
+    "marketing_campaign_name": {
+      "description": "For emails sent through our Marketing Campaigns feature, we add Marketing Campaigns specific parameters to the Event Webhook. Both marketing_campaign_name and marketing_campaign_id are displayed as unique arguments in the event data.",
+      "type": "string"
+    },
+    "marketing_campaign_version": {
+      "description": "Displayed in the event data for emails sent as part of an A/B Test. The value for marketing_campaign_version are returned as A, B, C, etc.",
+      "type": "string"
+    },
+    "marketing_campaign_split_id": {
+      "description": "Marketing campaign split id",
+      "type": "integer"
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/com.sendgrid/group_unsubscribe/jsonschema/3-0-0
+++ b/schemas/com.sendgrid/group_unsubscribe/jsonschema/3-0-0
@@ -1,0 +1,81 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Schema for a SendGrid group unsubscribe event. Property descriptions derived from the SendGrid documentation: https://sendgrid.com/docs/for-developers/tracking-events/event/",
+  "self": {
+    "vendor": "com.sendgrid",
+    "name": "group_unsubscribe",
+    "version": "3-0-0",
+    "format": "jsonschema"
+  },
+  "type": "object",
+  "properties": {
+    "ip": {
+      "description": "The IP address used to send the email. For open and click events, it is the IP address of the recipient who engaged with the email.",
+      "type": "string",
+      "maxLength": 45
+    },
+    "timestamp": {
+      "description": "The timestamp of when the message was sent",
+      "type": "string",
+      "format": "date-time"
+    },
+    "email": {
+      "description": "The email address of the recipient",
+      "type": "string",
+      "maxLength": 320
+    },
+    "url": {
+      "description": "The URL where the event originates. For click events, this is the URL clicked on by the recipient.",
+      "type": "string",
+      "format": "uri"
+    },
+    "sg_event_id": {
+      "description": "A unique ID to this event that you can use for deduplication purposes. These IDs are up to 100 characters long and are URL safe.",
+      "type": "string",
+      "minLength": 22,
+      "maxLength": 4096
+    },
+    "smtp-id": {
+      "description": "A unique ID attached to the message by the originating system",
+      "type": "string"
+    },
+    "useragent": {
+      "description": "The user agent responsible for the event. This is usually a web browser. For example, Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.95 Safari/537.36.",
+      "type": "string"
+    },
+    "category": {
+      "description": "Categories are custom tags that you set for the purpose of organizing your emails. Categories can be set as an array or string, and they will be returned as such when posted in your event endpoint.",
+      "type": ["array", "string"],
+      "items": {
+        "type": "string"
+      }
+    },
+    "asm_group_id": {
+      "description": "The ID of the unsubscribe group the recipient’s email address is included in. ASM IDs correspond to the ID that is returned when you create an unsubscribe group.",
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 9223372036854775807
+    },
+    "sg_message_id": {
+      "description": "A unique, internal SendGrid ID for the message. The first half of this is pulled from the smtp-id.",
+      "type": "string"
+    },
+    "marketing_campaign_id": {
+      "description": "For emails sent through our Marketing Campaigns feature, we add Marketing Campaigns specific parameters to the Event Webhook. Both marketing_campaign_name and marketing_campaign_id are displayed as unique arguments in the event data.",
+      "type": "integer"
+    },
+    "marketing_campaign_name": {
+      "description": "For emails sent through our Marketing Campaigns feature, we add Marketing Campaigns specific parameters to the Event Webhook. Both marketing_campaign_name and marketing_campaign_id are displayed as unique arguments in the event data.",
+      "type": "string"
+    },
+    "marketing_campaign_version": {
+      "description": "Displayed in the event data for emails sent as part of an A/B Test. The value for marketing_campaign_version are returned as A, B, C, etc.",
+      "type": "string"
+    },
+    "marketing_campaign_split_id": {
+      "description": "Marketing campaign split id",
+      "type": "integer"
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/com.sendgrid/open/jsonschema/3-0-0
+++ b/schemas/com.sendgrid/open/jsonschema/3-0-0
@@ -1,0 +1,92 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Schema for a SendGrid opened event. Property descriptions derived from the SendGrid documentation: https://sendgrid.com/docs/for-developers/tracking-events/event/",
+  "self": {
+    "vendor": "com.sendgrid",
+    "name": "open",
+    "version": "3-0-0",
+    "format": "jsonschema"
+  },
+  "type": "object",
+  "properties": {
+    "ip": {
+      "description": "The IP address used to send the email",
+      "type": "string",
+      "maxLength": 45
+    },
+    "timestamp": {
+      "description": "The timestamp of when the message was sent",
+      "type": "string",
+      "format": "date-time"
+    },
+    "email": {
+      "description": "The email address of the recipient",
+      "type": "string",
+      "maxLength": 320
+    },
+    "newsletter": {
+      "description": "Legacy Marketing Email tool fields",
+      "type": "object",
+      "properties": {
+        "newsletter_user_list_id": {
+          "type": "string"
+        },
+        "newsletter_id": {
+          "type": "string"
+        },
+        "newsletter_send_id": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": true
+    },
+    "sg_event_id": {
+      "description": "A unique ID to this event that you can use for deduplication purposes. These IDs are up to 100 characters long and are URL safe.",
+      "type": "string",
+      "minLength": 22,
+      "maxLength": 4096
+    },
+    "smtp-id": {
+      "description": "A unique ID attached to the message by the originating system",
+      "type": "string"
+    },
+    "useragent": {
+      "description": "The user agent responsible for the event. This is usually a web browser. For example, Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.95 Safari/537.36.",
+      "type": "string"
+    },
+    "category": {
+      "description": "Categories are custom tags that you set for the purpose of organizing your emails. Categories can be set as an array or string, and they will be returned as such when posted in your event endpoint.",
+      "type": ["array", "string"],
+      "items": {
+        "type": "string"
+      }
+    },
+    "asm_group_id": {
+      "description": "The ID of the unsubscribe group the recipient’s email address is included in. ASM IDs correspond to the ID that is returned when you create an unsubscribe group.",
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 9223372036854775807
+    },
+    "sg_message_id": {
+      "description": "A unique, internal SendGrid ID for the message. The first half of this is pulled from the smtp-id.",
+      "type": "string"
+    },
+    "marketing_campaign_id": {
+      "description": "For emails sent through our Marketing Campaigns feature, we add Marketing Campaigns specific parameters to the Event Webhook. Both marketing_campaign_name and marketing_campaign_id are displayed as unique arguments in the event data.",
+      "type": "integer"
+    },
+    "marketing_campaign_name": {
+      "description": "For emails sent through our Marketing Campaigns feature, we add Marketing Campaigns specific parameters to the Event Webhook. Both marketing_campaign_name and marketing_campaign_id are displayed as unique arguments in the event data.",
+      "type": "string"
+    },
+    "marketing_campaign_version": {
+      "description": "Displayed in the event data for emails sent as part of an A/B Test. The value for marketing_campaign_version are returned as A, B, C, etc.",
+      "type": "string"
+    },
+    "marketing_campaign_split_id": {
+      "description": "Marketing campaign split id",
+      "type": "integer"
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/com.sendgrid/processed/jsonschema/3-0-0
+++ b/schemas/com.sendgrid/processed/jsonschema/3-0-0
@@ -1,0 +1,89 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Schema for a SendGrid processed event. Property descriptions derived from the SendGrid documentation: https://sendgrid.com/docs/for-developers/tracking-events/event/",
+  "self": {
+    "vendor": "com.sendgrid",
+    "name": "processed",
+    "version": "3-0-0",
+    "format": "jsonschema"
+  },
+  "type": "object",
+  "properties": {
+    "timestamp": {
+      "description": "The timestamp of when the message was sent",
+      "type": "string",
+      "format": "date-time"
+    },
+    "email": {
+      "description": "The email address of the recipient",
+      "type": "string",
+      "maxLength": 320
+    },
+    "newsletter": {
+      "description": "Legacy Marketing Email tool fields",
+      "type": "object",
+      "properties": {
+        "newsletter_user_list_id": {
+          "type": "string"
+        },
+        "newsletter_id": {
+          "type": "string"
+        },
+        "newsletter_send_id": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": true
+    },
+    "sg_event_id": {
+      "description": "A unique ID to this event that you can use for deduplication purposes. These IDs are up to 100 characters long and are URL safe.",
+      "type": "string",
+      "minLength": 22,
+      "maxLength": 4096
+    },
+    "smtp-id": {
+      "description": "A unique ID attached to the message by the originating system",
+      "type": "string"
+    },
+    "category": {
+      "description": "Categories are custom tags that you set for the purpose of organizing your emails. Categories can be set as an array or string, and they will be returned as such when posted in your event endpoint.",
+      "type": ["array", "string"],
+      "items": {
+        "type": "string"
+      }
+    },
+    "asm_group_id": {
+      "description": "The ID of the unsubscribe group the recipient’s email address is included in. ASM IDs correspond to the ID that is returned when you create an unsubscribe group.",
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 9223372036854775807
+    },
+    "sg_message_id": {
+      "description": "A unique, internal SendGrid ID for the message. The first half of this is pulled from the smtp-id.",
+      "type": "string"
+    },
+    "send_at": {
+      "description": "To schedule a send request for a large batch of emails, use the send_at parameter which will send all emails at approximately the same time. send_at is a UNIX timestamp.",
+      "type": "integer",
+      "maximum": 2147483647,
+      "minimum": 0
+    },
+    "marketing_campaign_id": {
+      "description": "For emails sent through our Marketing Campaigns feature, we add Marketing Campaigns specific parameters to the Event Webhook. Both marketing_campaign_name and marketing_campaign_id are displayed as unique arguments in the event data.",
+      "type": "integer"
+    },
+    "marketing_campaign_name": {
+      "description": "For emails sent through our Marketing Campaigns feature, we add Marketing Campaigns specific parameters to the Event Webhook. Both marketing_campaign_name and marketing_campaign_id are displayed as unique arguments in the event data.",
+      "type": "string"
+    },
+    "marketing_campaign_version": {
+      "description": "Displayed in the event data for emails sent as part of an A/B Test. The value for marketing_campaign_version are returned as A, B, C, etc.",
+      "type": "string"
+    },
+    "marketing_campaign_split_id": {
+      "description": "Marketing campaign split id",
+      "type": "integer"
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/com.sendgrid/spamreport/jsonschema/3-0-0
+++ b/schemas/com.sendgrid/spamreport/jsonschema/3-0-0
@@ -1,0 +1,67 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Schema for a SendGrid spam report event. Property descriptions derived from the SendGrid documentation: https://sendgrid.com/docs/for-developers/tracking-events/event/",
+  "self": {
+    "vendor": "com.sendgrid",
+    "name": "spamreport",
+    "version": "3-0-0",
+    "format": "jsonschema"
+  },
+  "type": "object",
+  "properties": {
+    "timestamp": {
+      "description": "The timestamp of when the message was sent",
+      "type": "string",
+      "format": "date-time"
+    },
+    "email": {
+      "description": "The email address of the recipient",
+      "type": "string",
+      "maxLength": 320
+    },
+    "sg_event_id": {
+      "description": "A unique ID to this event that you can use for deduplication purposes. These IDs are up to 100 characters long and are URL safe.",
+      "type": "string",
+      "minLength": 22,
+      "maxLength": 4096
+    },
+    "smtp-id": {
+      "description": "A unique ID attached to the message by the originating system",
+      "type": "string"
+    },
+    "category": {
+      "description": "Categories are custom tags that you set for the purpose of organizing your emails. Categories can be set as an array or string, and they will be returned as such when posted in your event endpoint.",
+      "type": ["array", "string"],
+      "items": {
+        "type": "string"
+      }
+    },
+    "asm_group_id": {
+      "description": "The ID of the unsubscribe group the recipient’s email address is included in. ASM IDs correspond to the ID that is returned when you create an unsubscribe group.",
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 9223372036854775807
+    },
+    "sg_message_id": {
+      "description": "A unique, internal SendGrid ID for the message. The first half of this is pulled from the smtp-id.",
+      "type": "string"
+    },
+    "marketing_campaign_id": {
+      "description": "For emails sent through our Marketing Campaigns feature, we add Marketing Campaigns specific parameters to the Event Webhook. Both marketing_campaign_name and marketing_campaign_id are displayed as unique arguments in the event data.",
+      "type": "integer"
+    },
+    "marketing_campaign_name": {
+      "description": "For emails sent through our Marketing Campaigns feature, we add Marketing Campaigns specific parameters to the Event Webhook. Both marketing_campaign_name and marketing_campaign_id are displayed as unique arguments in the event data.",
+      "type": "string"
+    },
+    "marketing_campaign_version": {
+      "description": "Displayed in the event data for emails sent as part of an A/B Test. The value for marketing_campaign_version are returned as A, B, C, etc.",
+      "type": "string"
+    },
+    "marketing_campaign_split_id": {
+      "description": "Marketing campaign split id",
+      "type": "integer"
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/com.sendgrid/unsubscribe/jsonschema/3-0-0
+++ b/schemas/com.sendgrid/unsubscribe/jsonschema/3-0-0
@@ -1,0 +1,67 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Schema for a SendGrid unsubscribe event. Property descriptions derived from the SendGrid documentation: https://sendgrid.com/docs/for-developers/tracking-events/event/",
+  "self": {
+    "vendor": "com.sendgrid",
+    "name": "unsubscribe",
+    "version": "3-0-0",
+    "format": "jsonschema"
+  },
+  "type": "object",
+  "properties": {
+    "timestamp": {
+      "description": "The timestamp of when the message was sent",
+      "type": "string",
+      "format": "date-time"
+    },
+    "email": {
+      "description": "The email address of the recipient",
+      "type": "string",
+      "maxLength": 320
+    },
+    "sg_event_id": {
+      "description": "A unique ID to this event that you can use for deduplication purposes. These IDs are up to 100 characters long and are URL safe.",
+      "type": "string",
+      "minLength": 22,
+      "maxLength": 4096
+    },
+    "smtp-id": {
+      "description": "A unique ID attached to the message by the originating system",
+      "type": "string"
+    },
+    "category": {
+      "description": "Categories are custom tags that you set for the purpose of organizing your emails. Categories can be set as an array or string, and they will be returned as such when posted in your event endpoint.",
+      "type": ["array", "string"],
+      "items": {
+        "type": "string"
+      }
+    },
+    "asm_group_id": {
+      "description": "The ID of the unsubscribe group the recipient’s email address is included in. ASM IDs correspond to the ID that is returned when you create an unsubscribe group.",
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 9223372036854775807
+    },
+    "sg_message_id": {
+      "description": "A unique, internal SendGrid ID for the message. The first half of this is pulled from the smtp-id.",
+      "type": "string"
+    },
+    "marketing_campaign_id": {
+      "description": "For emails sent through our Marketing Campaigns feature, we add Marketing Campaigns specific parameters to the Event Webhook. Both marketing_campaign_name and marketing_campaign_id are displayed as unique arguments in the event data.",
+      "type": "integer"
+    },
+    "marketing_campaign_name": {
+      "description": "For emails sent through our Marketing Campaigns feature, we add Marketing Campaigns specific parameters to the Event Webhook. Both marketing_campaign_name and marketing_campaign_id are displayed as unique arguments in the event data.",
+      "type": "string"
+    },
+    "marketing_campaign_version": {
+      "description": "Displayed in the event data for emails sent as part of an A/B Test. The value for marketing_campaign_version are returned as A, B, C, etc.",
+      "type": "string"
+    },
+    "marketing_campaign_split_id": {
+      "description": "Marketing campaign split id",
+      "type": "integer"
+    }
+  },
+  "additionalProperties": true
+}


### PR DESCRIPTION
Issue #1309 
Following up on PR #1300 

Fixes validation errors in Sendgrid webhooks with the following changes:

* removes email validation from the `email` property since it may also contain invalid addresses (for emails that fail to be delivered). Instead, I added a 320 max length of the string.
* removes IP address validation from the `ip` property since Sendgrid sometimes sends `unknown` there. Instead, I added 45 character max length limit
* increases the maximum value for the `asm_group_id` from 32767 to 9223372036854775807 (hard to guess what is the actual limit since that is not documented)

Because of the changes in the maximum value of `asm_group_id`, these schemas need to update the major version to `3-0-0`.