### PR TITLE
Add schemas for tracker, iglu repo, and collector telemetry

### DIFF
--- a/schemas/com.snowplowanalytics.telemetry/collector_telemetry/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.telemetry/collector_telemetry/jsonschema/1-0-0
@@ -1,0 +1,60 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Schema for collector telemetry",
+  "self": {
+    "vendor": "com.snowplowanalytics.telemetry",
+    "name": "collector_telemetry",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "type": "object",
+  "properties": {
+    "collectorHost": {
+      "type": "string",
+      "description": "Host URL of the collector, e.g. https://collector.acme.com",
+      "format": "uri"
+    },
+    "collectorPath": {
+      "type": "string",
+      "description": "Path of the collector, e.g. /com.snowplowanalytics.snowplow/tp2"
+    },
+    "appId": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "The Application Identifier of the tracker",
+      "maxLength": 255
+    },
+    "pageUrl": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "Full URL of the page that sent the event",
+      "format": "uri"
+    },
+    "statusCode": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "description": "HTTP status code of the response",
+      "minimum": 0,
+      "maximum": 999
+    },
+    "method": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "HTTP method of the request e.g. GET, POST",
+      "maxLength": 20
+    }
+  },
+  "required": [
+    "collectorHost",
+    "collectorPath"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/com.snowplowanalytics.telemetry/collector_telemetry/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.telemetry/collector_telemetry/jsonschema/1-0-0
@@ -11,8 +11,7 @@
   "properties": {
     "collectorHost": {
       "type": "string",
-      "description": "Host URL of the collector, e.g. https://collector.acme.com",
-      "format": "uri"
+      "description": "Host URL of the collector, e.g. https://collector.acme.com"
     },
     "collectorPath": {
       "type": "string",

--- a/schemas/com.snowplowanalytics.telemetry/collector_telemetry/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.telemetry/collector_telemetry/jsonschema/1-0-0
@@ -25,6 +25,13 @@
       "description": "The Application Identifier of the tracker",
       "maxLength": 255
     },
+    "pageHost": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "Hostname of the page that the tracker is on"
+    },
     "statusCode": {
       "type": [
         "integer",

--- a/schemas/com.snowplowanalytics.telemetry/collector_telemetry/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.telemetry/collector_telemetry/jsonschema/1-0-0
@@ -25,14 +25,6 @@
       "description": "The Application Identifier of the tracker",
       "maxLength": 255
     },
-    "pageUrl": {
-      "type": [
-        "string",
-        "null"
-      ],
-      "description": "Full URL of the page that sent the event",
-      "format": "uri"
-    },
     "statusCode": {
       "type": [
         "integer",

--- a/schemas/com.snowplowanalytics.telemetry/iglu_repo_telemetry/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.telemetry/iglu_repo_telemetry/jsonschema/1-0-0
@@ -1,0 +1,44 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Schema for telemetry of an Iglu repository",
+  "self": {
+    "vendor": "com.snowplowanalytics.telemetry",
+    "name": "iglu_repo_telemetry",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "maxLength": 128,
+      "description": "The name of the repository"
+    },
+    "uri": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "format": "uri",
+      "description": "The URI of the repository"
+    },
+    "kind": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "local",
+        "ds",
+        "iglu",
+        "static"
+      ],
+      "description": "The kind of registry; Local, Data Structures API, Iglu Server, or Static HTTP"
+    }
+  },
+  "required": [
+    "name",
+    "kind"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/com.snowplowanalytics.telemetry/tracker_telemetry/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.telemetry/tracker_telemetry/jsonschema/1-0-0
@@ -1,0 +1,59 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Schema for tracker telemetry",
+  "self": {
+    "vendor": "com.snowplowanalytics.telemetry",
+    "name": "tracker_telemetry",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "type": "object",
+  "properties": {
+    "collectorHost": {
+      "type": "string",
+      "description": "Host URL of the tracker collector, e.g. https://collector.acme.com",
+      "format": "uri"
+    },
+    "collectorPath": {
+      "type": "string",
+      "description": "Path of the tracker collector, e.g. /com.snowplowanalytics.snowplow/tp2"
+    },
+    "appId": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "The Application Identifier of the tracker",
+      "maxLength": 255
+    },
+    "trackerNamespace": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "The namespace of the tracker",
+      "maxLength": 128
+    },
+    "trackerVersion": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "The tracker version",
+      "maxLength": 100
+    },
+    "pageUrl": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "Full URL of the page that the tracker is running on",
+      "format": "uri"
+    }
+  },
+  "required": [
+    "collectorHost",
+    "collectorPath"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/com.snowplowanalytics.telemetry/tracker_telemetry/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.telemetry/tracker_telemetry/jsonschema/1-0-0
@@ -11,8 +11,7 @@
   "properties": {
     "collectorHost": {
       "type": "string",
-      "description": "Host URL of the tracker collector, e.g. https://collector.acme.com",
-      "format": "uri"
+      "description": "Host URL of the tracker collector, e.g. https://collector.acme.com"
     },
     "collectorPath": {
       "type": "string",

--- a/schemas/com.snowplowanalytics.telemetry/tracker_telemetry/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.telemetry/tracker_telemetry/jsonschema/1-0-0
@@ -40,14 +40,6 @@
       ],
       "description": "The tracker version",
       "maxLength": 100
-    },
-    "pageUrl": {
-      "type": [
-        "string",
-        "null"
-      ],
-      "description": "Full URL of the page that the tracker is running on",
-      "format": "uri"
     }
   },
   "required": [


### PR DESCRIPTION
This PR adds 3 schemas for the telemetry of trackers, collectors and iglu repos found in the wild:

### `com.snowplowanalytics.telemetry/collector_telemetry/jsonschema/1-0-0`

This is to be used with the upcoming [runnable snippets](https://github.com/snowplow/documentation/pull/446) documentation feature to help with discover what collectors may be out there in the wild by tracking the collector URLs entered by users, along with being used by the poplin extension to replace the [endpoint analytics struct event](https://github.com/poplindata/chrome-snowplow-inspector/blob/6295f4f6c3c7a39c45a037bfd61bbbbba9f53393/src/ts/analytics.ts#L58). 

### `com.snowplowanalytics.telemetry/tracker_telemetry/jsonschema/1-0-0`

Used for analytics on created trackers in the runnable snippets UI, and [tracker analytics](https://github.com/poplindata/chrome-snowplow-inspector/blob/6295f4f6c3c7a39c45a037bfd61bbbbba9f53393/src/ts/analytics.ts#L18) in the poplin extension.

### `com.snowplowanalytics.telemetry/iglu_repo_telemetry/jsonschema/1-0-0`

This is a schema specifically for the poplin extension, for use in [repo analytics](https://github.com/poplindata/chrome-snowplow-inspector/blob/6295f4f6c3c7a39c45a037bfd61bbbbba9f53393/src/ts/analytics.ts#L102). 
