### PR TITLE
Update org.w3/PerformanceTiming SQL file

### DIFF
--- a/sql/org.w3/performance_timing_1.sql
+++ b/sql/org.w3/performance_timing_1.sql
@@ -15,45 +15,51 @@
 --
 -- Compatibility: iglu:org.w3/PerformanceTiming/jsonschema/1-0-0
 
-CREATE TABLE atomic.org_w3_performance_timing_1 (
-	-- Schema of this type
-	schema_vendor                  VARCHAR(128)  ENCODE ZSTD NOT NULL,
-	schema_name                    VARCHAR(128)  ENCODE ZSTD NOT NULL,
-	schema_format                  VARCHAR(128)  ENCODE ZSTD NOT NULL,
-	schema_version                 VARCHAR(128)  ENCODE ZSTD NOT NULL,
-	-- Parentage of this type
-	root_id                        CHAR(36)      ENCODE ZSTD NOT NULL,
-	root_tstamp                    TIMESTAMP     ENCODE RAW  NOT NULL,
-	ref_root                       VARCHAR(255)  ENCODE ZSTD NOT NULL,
-	ref_tree                       VARCHAR(1500) ENCODE ZSTD NOT NULL,
-	ref_parent                     VARCHAR(255)  ENCODE ZSTD NOT NULL,
-	-- Properties of this type
-	navigation_start               BIGINT ENCODE ZSTD,
-	redirect_start                 BIGINT ENCODE ZSTD,
-	redirect_end                   BIGINT ENCODE ZSTD,
-	fetch_start                    BIGINT ENCODE ZSTD,
-	domain_lookup_start            BIGINT ENCODE ZSTD,
-	domain_lookup_end              BIGINT ENCODE ZSTD,
-	secure_connection_start        BIGINT ENCODE ZSTD,
-	connect_start                  BIGINT ENCODE ZSTD,
-	connect_end                    BIGINT ENCODE ZSTD,
-	request_start                  BIGINT ENCODE ZSTD,
-	response_start                 BIGINT ENCODE ZSTD,
-	response_end                   BIGINT ENCODE ZSTD,
-	unload_event_start             BIGINT ENCODE ZSTD,
-	unload_event_end               BIGINT ENCODE ZSTD,
-	dom_loading                    BIGINT ENCODE ZSTD,
-	dom_interactive                BIGINT ENCODE ZSTD,
-	dom_content_loaded_event_start BIGINT ENCODE ZSTD,
-	dom_content_loaded_event_end   BIGINT ENCODE ZSTD,
-	dom_complete                   BIGINT ENCODE ZSTD,
-	load_event_start               BIGINT ENCODE ZSTD,
-	load_event_end                 BIGINT ENCODE ZSTD,
-	ms_first_paint                 BIGINT ENCODE ZSTD,
-	chrome_first_paint             BIGINT ENCODE ZSTD,
-	FOREIGN KEY(root_id) REFERENCES atomic.events(event_id)
+CREATE SCHEMA IF NOT EXISTS atomic;
+
+CREATE TABLE IF NOT EXISTS atomic.org_w3_performance_timing_1 (
+    -- Schema of this type
+    "schema_vendor"                  VARCHAR(128)  ENCODE ZSTD NOT NULL,
+    "schema_name"                    VARCHAR(128)  ENCODE ZSTD NOT NULL,
+    "schema_format"                  VARCHAR(128)  ENCODE ZSTD NOT NULL,
+    "schema_version"                 VARCHAR(128)  ENCODE ZSTD NOT NULL,
+    -- Parentage of this type
+    "root_id"                        CHAR(36)      ENCODE RAW  NOT NULL,
+    "root_tstamp"                    TIMESTAMP     ENCODE ZSTD NOT NULL,
+    "ref_root"                       VARCHAR(255)  ENCODE ZSTD NOT NULL,
+    "ref_tree"                       VARCHAR(1500) ENCODE ZSTD NOT NULL,
+    "ref_parent"                     VARCHAR(255)  ENCODE ZSTD NOT NULL,
+    -- Properties of this type
+    "chrome_first_paint"             BIGINT        ENCODE ZSTD,
+    "connect_end"                    BIGINT        ENCODE ZSTD,
+    "connect_start"                  BIGINT        ENCODE ZSTD,
+    "dom_complete"                   BIGINT        ENCODE ZSTD,
+    "dom_content_loaded_event_end"   BIGINT        ENCODE ZSTD,
+    "dom_content_loaded_event_start" BIGINT        ENCODE ZSTD,
+    "dom_interactive"                BIGINT        ENCODE ZSTD,
+    "dom_loading"                    BIGINT        ENCODE ZSTD,
+    "domain_lookup_end"              BIGINT        ENCODE ZSTD,
+    "domain_lookup_start"            BIGINT        ENCODE ZSTD,
+    "fetch_start"                    BIGINT        ENCODE ZSTD,
+    "load_event_end"                 BIGINT        ENCODE ZSTD,
+    "load_event_start"               BIGINT        ENCODE ZSTD,
+    "ms_first_paint"                 BIGINT        ENCODE ZSTD,
+    "navigation_start"               BIGINT        ENCODE ZSTD,
+    "proxy_end"                      BIGINT        ENCODE ZSTD,
+    "proxy_start"                    BIGINT        ENCODE ZSTD,
+    "redirect_end"                   BIGINT        ENCODE ZSTD,
+    "redirect_start"                 BIGINT        ENCODE ZSTD,
+    "request_end"                    BIGINT        ENCODE ZSTD,
+    "request_start"                  BIGINT        ENCODE ZSTD,
+    "response_end"                   BIGINT        ENCODE ZSTD,
+    "response_start"                 BIGINT        ENCODE ZSTD,
+    "secure_connection_start"        BIGINT        ENCODE ZSTD,
+    "unload_event_end"               BIGINT        ENCODE ZSTD,
+    "unload_event_start"             BIGINT        ENCODE ZSTD,
+    FOREIGN KEY (root_id) REFERENCES atomic.events(event_id)
 )
 DISTSTYLE KEY
--- Optimized join to atomic.events
 DISTKEY (root_id)
 SORTKEY (root_tstamp);
+
+COMMENT ON TABLE atomic.org_w3_performance_timing_1 IS 'iglu:org.w3/PerformanceTiming/jsonschema/1-0-0';


### PR DESCRIPTION
### Overview

The SQL file for the [org.w3/PerformanceTiming/jsonschema/1-0-0](https://github.com/snowplow/iglu-central/blob/master/schemas/org.w3/PerformanceTiming/jsonschema/1-0-0) schema seems to be out of date (?).

This change adds the 5 missing columns (that are present in the schema) and re-orders the columns (like the latest versions of Snowplow would expect it?).
- `proxy_start`
- `proxy_end`
- `request_end`
- `unload_event_end`
- `unload_event_start`

The SQL statement was generated using `igluctl 0.11.3` against the [org.w3/PerformanceTiming/jsonschema/1-0-0](https://github.com/snowplow/iglu-central/blob/master/schemas/org.w3/PerformanceTiming/jsonschema/1-0-0) schema in the `master` branch.