### PR TITLE
Add com.snowplowanalytics.snowplow/button_click/jsonschema/1-0-0 (close #1351)

### DIFF
--- a/schemas/com.snowplowanalytics.snowplow/button_click/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.snowplow/button_click/jsonschema/1-0-0
@@ -1,0 +1,50 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Schema for a button click event",
+  "self": {
+    "vendor": "com.snowplowanalytics.snowplow",
+    "name": "button_click",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "type": "object",
+  "properties": {
+    "label": {
+      "type": "string",
+      "description": "The text on the button clicked, or a user-provided override",
+      "minLength": 1,
+      "maxLength": 4096
+    },
+    "id": {
+      "description": "The ID of the button clicked, if present",
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 4096
+    },
+    "classes": {
+      "description": "An array of class names from the button clicked",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": "string",
+        "maxLength": 4096
+      }
+    },
+    "name": {
+      "description": "The name of the button, if present",
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 4096
+    }
+  },
+  "required": [
+    "label"
+  ],
+  "additionalProperties": false
+}


### PR DESCRIPTION
This PR adds a schema for button clicks, in the same vein as the existing [link_click](https://github.com/snowplow/iglu-central/blob/8ff48b2485b3c95447e38a9bb925ef3f5266112c/schemas/com.snowplowanalytics.snowplow/link_click/jsonschema/1-0-1) schema. This will be used in the upcoming OTB Button Click event in the JS tracker.