### PR TITLE
Add schemas for screen engagement tracking on mobile

### DIFF
--- a/schemas/com.snowplowanalytics.mobile/list_item_view/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.mobile/list_item_view/jsonschema/1-0-0
@@ -1,0 +1,32 @@
+{
+	"$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+	"description": "Schema for an event tracked when an item is displayed in a list",
+	"self": {
+		"vendor": "com.snowplowanalytics.mobile",
+		"name": "list_item_view",
+		"format": "jsonschema",
+		"version": "1-0-0"
+	},
+	"type": "object",
+	"properties": {
+		"index": {
+			"type": "integer",
+			"description": "Index of the item in a list on the screen",
+			"minimum": 0,
+			"maximum": 65535
+		},
+		"items_count": {
+			"type": [
+				"integer",
+				"null"
+			],
+			"description": "Total number of items in a list on the screen",
+			"minimum": 0,
+			"maximum": 65535
+		}
+	},
+	"required": [
+		"index"
+	],
+	"additionalProperties": false
+}

--- a/schemas/com.snowplowanalytics.mobile/screen_end/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.mobile/screen_end/jsonschema/1-0-0
@@ -1,0 +1,13 @@
+{
+	"$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+	"description": "Schema for an event tracked before transitioning to a new screen",
+	"self": {
+		"vendor": "com.snowplowanalytics.mobile",
+		"name": "screen_end",
+		"format": "jsonschema",
+		"version": "1-0-0"
+	},
+	"type": "object",
+	"properties": {},
+	"additionalProperties": false
+}

--- a/schemas/com.snowplowanalytics.mobile/screen_summary/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.mobile/screen_summary/jsonschema/1-0-0
@@ -1,0 +1,104 @@
+{
+	"$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+	"description": "Schema for an entity tracked with foreground/background/screen_end events with summary statistics about the screen view",
+	"self": {
+		"vendor": "com.snowplowanalytics.mobile",
+		"name": "screen_summary",
+		"format": "jsonschema",
+		"version": "1-0-0"
+	},
+	"type": "object",
+	"properties": {
+		"foreground_sec": {
+			"type": "number",
+			"description": "Time in seconds spent on the current screen while the app was in foreground",
+			"minimum": 0,
+			"maximum": 2147483647
+		},
+		"background_sec": {
+			"type": [
+				"number",
+				"null"
+			],
+			"description": "Time in seconds spent on the current screen while the app was in background",
+			"minimum": 0,
+			"maximum": 2147483647
+		},
+		"last_item_index": {
+			"type": [
+				"integer",
+				"null"
+			],
+			"description": "Index of the last viewed item in the list on the screen",
+			"minimum": 0,
+			"maximum": 65535
+		},
+		"items_count": {
+			"type": [
+				"integer",
+				"null"
+			],
+			"description": "Total number of items in the list on the screen",
+			"minimum": 0,
+			"maximum": 65535
+		},
+		"min_x_offset": {
+			"type": [
+				"integer",
+				"null"
+			],
+			"description": "Minimum horizontal scroll offset on the scroll view in pixels",
+			"minimum": -2147483647,
+			"maximum": 2147483647
+		},
+		"max_x_offset": {
+			"type": [
+				"integer",
+				"null"
+			],
+			"description": "Maximum horizontal scroll offset on the scroll view in pixels",
+			"minimum": -2147483647,
+			"maximum": 2147483647
+		},
+		"min_y_offset": {
+			"type": [
+				"integer",
+				"null"
+			],
+			"description": "Minimum vertical scroll offset on the scroll view in pixels",
+			"minimum": -2147483647,
+			"maximum": 2147483647
+		},
+		"max_y_offset": {
+			"type": [
+				"integer",
+				"null"
+			],
+			"description": "Maximum vertical scroll offset on the scroll view in pixels",
+			"minimum": -2147483647,
+			"maximum": 2147483647
+		},
+		"content_width": {
+			"type": [
+				"integer",
+				"null"
+			],
+			"description": "Width of the scroll view in pixels",
+			"minimum": 0,
+			"maximum": 2147483647
+		},
+		"content_height": {
+			"type": [
+				"integer",
+				"null"
+			],
+			"description": "Height of the scroll view in pixels",
+			"minimum": 0,
+			"maximum": 2147483647
+		}
+	},
+	"required": [
+		"foreground_sec"
+	],
+	"additionalProperties": false
+}

--- a/schemas/com.snowplowanalytics.mobile/scroll_changed/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.mobile/scroll_changed/jsonschema/1-0-0
@@ -1,0 +1,68 @@
+{
+	"$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+	"description": "Schema for an event tracked when a scroll view's scroll position changes",
+	"self": {
+		"vendor": "com.snowplowanalytics.mobile",
+		"name": "scroll_changed",
+		"format": "jsonschema",
+		"version": "1-0-0"
+	},
+	"type": "object",
+	"properties": {
+		"x_offset": {
+			"type": [
+				"integer",
+				"null"
+			],
+			"description": "Horizontal scroll offset in pixels",
+			"minimum": -2147483647,
+			"maximum": 2147483647
+		},
+		"y_offset": {
+			"type": [
+				"integer",
+				"null"
+			],
+			"description": "Vertical scroll offset in pixels",
+			"minimum": -2147483647,
+			"maximum": 2147483647
+		},
+		"view_width": {
+			"type": [
+				"integer",
+				"null"
+			],
+			"description": "The width of the scroll view in pixels",
+			"minimum": 0,
+			"maximum": 2147483647
+		},
+		"view_height": {
+			"type": [
+				"integer",
+				"null"
+			],
+			"description": "The height of the scroll view in pixels",
+			"minimum": 0,
+			"maximum": 2147483647
+		},
+		"content_width": {
+			"type": [
+				"integer",
+				"null"
+			],
+			"description": "The width of the content in the scroll view in pixels",
+			"minimum": 0,
+			"maximum": 2147483647
+		},
+		"content_height": {
+			"type": [
+				"integer",
+				"null"
+			],
+			"description": "The height of the content in the scroll view in pixels",
+			"minimum": 0,
+			"maximum": 2147483647
+		}
+	},
+	"additionalProperties": false
+}


### PR DESCRIPTION
This PR adds 3 schemas for screen engagement tracking on mobile (`screen_time` and `screen_end`) and both on mobile and Web (`view_segment`).

These schema support the proposal presented [in this demo](https://f001.backblazeb2.com/file/referred/snowplow-screen-engagement-demo/index.html).

* com.snowplowanalytics.snowplow/screen_summary/jsonschema/1-0-0
   * schema for entity tracked with mobile events (foreground/background/scren_end) with duration of the screen in foreground and background
* com.snowplowanalytics.snowplow/screen_end/jsonschema/1-0-0
   * schema for event tracked before transitioning to the next screen on mobile. it doesn't have any properties but will be tracked with the `screen_time` and `view_segment` entities