### PR TITLE
Add schemas for visionOS

### DIFF
--- a/schemas/com.apple.swiftui/dismiss_immersive_space/jsonschema/1-0-0
+++ b/schemas/com.apple.swiftui/dismiss_immersive_space/jsonschema/1-0-0
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "self": {
+    "vendor": "com.apple.swiftui",
+    "name": "dismiss_immersive_space",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "description": "Schema for an event for dismissing a visionOS immersive space.",
+  "type": "object",
+  "properties": {},
+  "additionalProperties": false
+}

--- a/schemas/com.apple.swiftui/dismiss_window/jsonschema/1-0-0
+++ b/schemas/com.apple.swiftui/dismiss_window/jsonschema/1-0-0
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "self": {
+    "vendor": "com.apple.swiftui",
+    "name": "dismiss_window",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "description": "Schema for an event for dismissing a SwiftUI window or window group.",
+  "type": "object",
+  "properties": {},
+  "additionalProperties": false
+}

--- a/schemas/com.apple.swiftui/immersive_space/jsonschema/1-0-0
+++ b/schemas/com.apple.swiftui/immersive_space/jsonschema/1-0-0
@@ -1,0 +1,48 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "self": {
+    "vendor": "com.apple.swiftui",
+    "name": "immersive_space",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "description": "Schema for an immersive space entity, representing the VisionOS immersive space that the event occurs in.",
+  "type": "object",
+  "properties": {
+    "view_id": {
+      "type": ["string", "null"],
+      "format": "uuid",
+      "description": "UUID for the view of the immersive space."
+    },
+    "id": {
+      "type": "string",
+      "description": "The identifier of the immersive space to present.",
+      "maxLength": 255
+    },
+    "immersion_style": {
+      "type": ["string", "null"],
+      "enum": [
+        "automatic",
+        "full",
+        "mixed",
+        "progressive",
+        null
+      ],
+      "description": "The style of an immersive space."
+    },
+    "upper_limb_visibility": {
+      "type": ["string", "null"],
+      "enum": [
+        "automatic",
+        "visible",
+        "hidden",
+        null
+      ],
+      "description": "Preferred visibility of the user's upper limbs, while an immersive space scene is presented."
+    }
+  },
+  "required": [
+    "id"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/com.apple.swiftui/open_immersive_space/jsonschema/1-0-0
+++ b/schemas/com.apple.swiftui/open_immersive_space/jsonschema/1-0-0
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "self": {
+    "vendor": "com.apple.swiftui",
+    "name": "open_immersive_space",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "description": "Schema for an event for opening a visionOS immersive space.",
+  "type": "object",
+  "properties": {},
+  "additionalProperties": false
+}

--- a/schemas/com.apple.swiftui/open_window/jsonschema/1-0-0
+++ b/schemas/com.apple.swiftui/open_window/jsonschema/1-0-0
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "self": {
+    "vendor": "com.apple.swiftui",
+    "name": "open_window",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "description": "Schema for an event for opening a SwiftUI window or window group.",
+  "type": "object",
+  "properties": {},
+  "additionalProperties": false
+}

--- a/schemas/com.apple.swiftui/window_group/jsonschema/1-0-0
+++ b/schemas/com.apple.swiftui/window_group/jsonschema/1-0-0
@@ -1,0 +1,47 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "self": {
+    "vendor": "com.apple.swiftui",
+    "name": "window_group",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "description": "Schema for a window group entity, representing the SwiftUI window group that the event occurs in.",
+  "type": "object",
+  "properties": {
+    "window_id": {
+      "type": ["string", "null"],
+      "format": "uuid",
+      "description": "UUID for the current window within the group."
+    },
+    "id": {
+      "type": "string",
+      "description": "A string that uniquely identifies the window group. Identifiers must be unique among the window groups in your app.",
+      "maxLength": 255
+    },
+    "title_key": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "A localized string key to use for the window's title in system menus and in the window's title bar. Provide a title that describes the purpose of the window.",
+      "maxLength": 4096
+    },
+    "window_style": {
+      "type": ["string", "null"],
+      "enum": [
+        "automatic",
+        "hiddenTitleBar",
+        "plain",
+        "titleBar",
+        "volumetric",
+        null
+      ],
+      "description": "A specification for the appearance and interaction of a window."
+    }
+  },
+  "required": [
+    "id"
+  ],
+  "additionalProperties": false
+}


### PR DESCRIPTION
This PR adds schemas based on various SwiftUI objects. They will allow users to track activity in visionOS apps. For issue #1367.