### PR TITLE
Add new loader alert schema

### DIFF
--- a/schemas/com.snowplowanalytics.monitoring.loader/alert/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.monitoring.loader/alert/jsonschema/1-0-0
@@ -1,0 +1,35 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Webhook payload describing an alert coming from loader",
+  "self": {
+    "vendor": "com.snowplowanalytics.monitoring.loader",
+    "name": "alert",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "type": "object",
+  "properties": {
+    "appName": {
+      "type": "string",
+      "maxLength": 64,
+      "description": "Application's name"
+    },
+    "appVersion": {
+      "type": "string",
+      "maxLength": 64,
+      "description": "Application's version"
+    },
+    "message": {
+      "description": "Free-form message describing the problem",
+      "maxLength": 4096,
+      "type": "string"
+    },
+    "tags": {
+      "description": "Set of key value pairs providing additional information",
+      "type": "object",
+      "additionalProperties": { "type": "string" }
+    }
+  },
+  "required": ["appName", "appVersion", "message", "tags"],
+  "additionalProperties": false
+}


### PR DESCRIPTION
Similar to the alert schema used by RDB Loader -> https://github.com/snowplow/iglu-central/blob/master/schemas/com.snowplowanalytics.monitoring.batch/alert/jsonschema/1-0-0, but only with 3 fields: 

* `application`
* `message`
* `tags`