### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -13,7 +13,7 @@ jobs:
 
       - name: Extract tag version from ref
         id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+        run: echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
 
       - name: is_release_tag check
         id: tag_check
@@ -21,7 +21,7 @@ jobs:
           RELEASE_TAG: ${{ steps.get_version.outputs.VERSION }}
         run: |
           ./.github/scripts/is_release_tag.bash $RELEASE_TAG
-          echo ::set-output name=exit_code::$?
+          echo "exit_code=$?" >> $GITHUB_OUTPUT
 
       - name: Debug is_release_tag check
         env:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -13,7 +13,7 @@ jobs:
 
       - name: Extract tag version from ref
         id: get_version
-        run: echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
+        run: echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> "$GITHUB_OUTPUT"
 
       - name: is_release_tag check
         id: tag_check
@@ -21,7 +21,7 @@ jobs:
           RELEASE_TAG: ${{ steps.get_version.outputs.VERSION }}
         run: |
           ./.github/scripts/is_release_tag.bash $RELEASE_TAG
-          echo "exit_code=$?" >> $GITHUB_OUTPUT
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
 
       - name: Debug is_release_tag check
         env:


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


