### PR TITLE
Add com.snowplowanalytics.snowplow/client_session/jsonschema/1-0-3 (close #1410)

### DIFF
--- a/schemas/com.snowplowanalytics.snowplow/client_session/jsonschema/1-0-2
+++ b/schemas/com.snowplowanalytics.snowplow/client_session/jsonschema/1-0-2
@@ -1,5 +1,6 @@
 {
 	"$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+	"$supersededBy": "1-0-3",
 	"description": "Schema for a client-generated user session",
 	"self": {
 		"vendor": "com.snowplowanalytics.snowplow",

--- a/schemas/com.snowplowanalytics.snowplow/client_session/jsonschema/1-0-3
+++ b/schemas/com.snowplowanalytics.snowplow/client_session/jsonschema/1-0-3
@@ -1,0 +1,82 @@
+{
+	"$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+	"$supersedes": ["1-0-2"],
+	"description": "Schema for a client-generated user session",
+	"self": {
+		"vendor": "com.snowplowanalytics.snowplow",
+		"name": "client_session",
+		"format": "jsonschema",
+		"version": "1-0-3"
+	},
+	"type": "object",
+	"properties": {
+		"userId": {
+			"type": "string",
+			"pattern": "^[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}$|^[0-9a-f]{16}$",
+			"maxLength": 36,
+			"description": "An identifier for the user of the session"
+		},
+		"sessionId": {
+			"type": "string",
+			"format": "uuid",
+			"description": "An identifier for the session"
+		},
+		"sessionIndex": {
+			"type": "integer",
+			"minimum": 0,
+			"maximum": 2147483647,
+			"description": "The index of the current session for this user"
+		},
+		"eventIndex": {
+			"type": [
+				"null",
+				"integer"
+			],
+			"minimum": 0,
+			"maximum": 2147483647,
+			"description": "Optional index of the current event in the session"
+		},
+		"previousSessionId": {
+			"type": [
+				"null",
+				"string"
+			],
+			"format": "uuid",
+			"description": "The previous session identifier for this user"
+		},
+		"storageMechanism": {
+			"type": "string",
+			"enum": [
+				"SQLITE",
+				"COOKIE_1",
+				"COOKIE_3",
+				"LOCAL_STORAGE",
+				"FLASH_LSO"
+			],
+			"description": "The mechanism that the session information has been stored on the device"
+		},
+		"firstEventId": {
+			"type": [
+				"null",
+				"string"
+			],
+			"format": "uuid",
+			"description": "The optional identifier of the first event for this session"
+		},
+		"firstEventTimestamp": {
+			"description": "Optional date-time timestamp of when the first event in the session was tracked",
+			"type": [
+				"null",
+				"string"
+			],
+			"format": "date-time"
+		}
+	},
+	"required": [
+		"userId",
+		"sessionId",
+		"sessionIndex",
+		"storageMechanism"
+	],
+	"additionalProperties": false
+}


### PR DESCRIPTION
Issue #1410 

This PR adds the `1-0-3` version of the `client_session` entity that has only one change compared to the `1-0-2` version:  it makes the `previousSessionId` property non-required. The property is nullable, so making it non-required should not be a breaking change.

The reason for this update is a customer issue where their mobile apps in production seem to be tracking events with the entity but for some reason are omitting the null value. We are unable to reproduce and thus fix in the tracker, but we have seen this in the past a few times, so making the schema resilient to this is the only option for us.

Also making the schema supersede the `1-0-2` schema so that it is automatically applied to events tracked with the `1-0-2` entity.

It is somewhat urgent as the customer is pushing for us since they are seeing failed events in production.