### PR TITLE
Release/r161

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Release 161 (2024-07-29)
+------------------------
+Patch com.snowplowanalytics.snowplow/client_session/jsonschema/1-0-2 (#1410)
+
 Release 160 (2024-07-17)
 ------------------------
 Add com.snowplowanalytics.snowplow/custom_event/jsonschema/1-0-0 (close #1407)

--- a/schemas/com.snowplowanalytics.snowplow/client_session/jsonschema/1-0-2
+++ b/schemas/com.snowplowanalytics.snowplow/client_session/jsonschema/1-0-2
@@ -75,7 +75,6 @@
 		"userId",
 		"sessionId",
 		"sessionIndex",
-		"previousSessionId",
 		"storageMechanism"
 	],
 	"additionalProperties": false


### PR DESCRIPTION
This release contains the schema for the `client_session` entity version 1-0-3 that supersedes the 1-0-2 version. It adds the `$supersededBy` relation to the 1-0-2 version and the `supersedes` relation to the 1-0-3 version. The change in the 1-0-3 schema is that the `previousSessionId` property is no longer required (not a breaking change since it was nullable).

**Changes**
* Add com.snowplowanalytics.snowplow/client_session/jsonschema/1-0-3 (#1410)
* Patch com.snowplowanalytics.snowplow/client_session/jsonschema/1-0-2 (#1410)

Needs extra attention as this is the first time that we use the supersedes relation in Iglu Central and the `client_session` schema is a popular one.