### PR TITLE
Add com.snowplowanalytics.snowplow/application/jsonschema/1-0-0 (close #1418)

### DIFF
--- a/schemas/com.snowplowanalytics.snowplow/application/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.snowplow/application/jsonschema/1-0-0
@@ -1,0 +1,20 @@
+{
+	"$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+	"description": "Schema for an application context which tracks the app version.",
+	"self": {
+		"vendor": "com.snowplowanalytics.snowplow",
+		"name": "application",
+		"format": "jsonschema",
+		"version": "1-0-0"
+	},
+	"type": "object",
+	"properties": {
+		"version": {
+			"type": "string",
+			"description": "Version of the application. Can be a semver-like structure (e.g 1.1.0) or a Git commit SHA hash.",
+			"maxLength": 255
+		}
+	},
+	"required": ["version"],
+	"additionalProperties": false
+}


### PR DESCRIPTION
Add a schema for the application context entity tracked in Web and other apps that specifies the version number of the application. This can be in the form of semver or a Git commit SHA, so the schema doesn't put any further limits on it other than the max length.

Note that [we already have a `application` context entity](https://github.com/snowplow/iglu-central/blob/master/schemas/com.snowplowanalytics.mobile/application/jsonschema/1-0-0) that is tracked on mobile – it has the vendor `com.snowplowanalytics.mobile`. In addition to the version, it also has a required `build` property that is available in mobile app builds. We can't reuse the same as the `build` number is not so useful on Web apps.