### PR TITLE
Element Tracking Plugin Schemas

### DIFF
--- a/schemas/com.snowplowanalytics.snowplow/component_parents/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.snowplow/component_parents/jsonschema/1-0-0
@@ -1,0 +1,30 @@
+{
+  "description": "Entity describing the list of components that were found to contain the element with the named configuration.",
+  "properties": {
+    "element_name": {
+      "description": "Name of the element that this entity relates to, if any. If not provided, may apply to a subject of some other event, such as Link, Button, or Form Tracking events.",
+      "type": ["string", "null"],
+      "maxLength": 255
+    },
+    "component_list": {
+      "description": "List of component names that were detected as containing the element that is the subject of this event.",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "description": "Component name found to contain this element. This should match a component configuration name.",
+        "type": "string",
+        "maxLength": 255
+      }
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": ["component_list"],
+  "self": {
+    "vendor": "com.snowplowanalytics.snowplow",
+    "name": "component_parents",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#"
+}

--- a/schemas/com.snowplowanalytics.snowplow/create_element/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.snowplow/create_element/jsonschema/1-0-0
@@ -1,0 +1,20 @@
+{
+  "description": "Event that fires when an element matching a named configuration is detected as existing in or being added to a document.",
+  "properties": {
+    "element_name": {
+      "description": "The name of the element that was created. Should match the element name field in entities that describe this particular element.",
+      "type": "string",
+      "maxLength": 255
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": ["element_name"],
+  "self": {
+    "vendor": "com.snowplowanalytics.snowplow",
+    "name": "create_element",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#"
+}

--- a/schemas/com.snowplowanalytics.snowplow/destroy_element/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.snowplow/destroy_element/jsonschema/1-0-0
@@ -1,0 +1,20 @@
+{
+  "description": "Event that fires when an element matching a named configuration is detected as being removed from a document.",
+  "properties": {
+    "element_name": {
+      "description": "The name of the element that was destroyed. Should match the element name field in entities that describe this particular element.",
+      "type": "string",
+      "maxLength": 255
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": ["element_name"],
+  "self": {
+    "vendor": "com.snowplowanalytics.snowplow",
+    "name": "destroy_element",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#"
+}

--- a/schemas/com.snowplowanalytics.snowplow/element/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.snowplow/element/jsonschema/1-0-0
@@ -1,0 +1,85 @@
+{
+  "description": "Entity detailing a specific element matched using the Element Tracking plugin.",
+  "properties": {
+    "element_name": {
+      "description": "The name of the element configuration that this entity is detailing.",
+      "type": "string",
+      "maxLength": 255
+    },
+    "originating_page_view": {
+      "description": "The active page view ID when this element was first observed. For elements that persist across multiple pageviews, this is the pageview the element originated on and may be different to the current pageview ID of this event. May be empty if the element has not actually been observed yet.",
+      "type": "string",
+      "maxLength": 36
+    },
+    "height": {
+      "description": "The height of the named element at time of event, in virtual pixels.",
+      "type": "number"
+    },
+    "width": {
+      "description": "The width of the named element at time of event, in virtual pixels.",
+      "type": "number"
+    },
+    "position_x": {
+      "description": "The offset position of the named element at time of event, in virtual pixels from the left side of the viewport.",
+      "type": "number"
+    },
+    "position_y": {
+      "description": "The offset position of the named element at time of event, in virtual pixels from the top side of the viewport.",
+      "type": "number"
+    },
+    "doc_position_x": {
+      "description": "The offset position of the named element at time of event, in virtual pixels from the left side of the document.",
+      "type": "number"
+    },
+    "doc_position_y": {
+      "description": "The offset position of the named element at time of event, in virtual pixels from the top side of the document.",
+      "type": "number"
+    },
+    "element_index": {
+      "description": "The index of the named element among other elements that match it's selector within the document. (one-based, out of `element_matches` in document)",
+      "type": "integer",
+      "minimum": 1
+    },
+    "element_matches": {
+      "description": "The number of elements that match the named element's configured selector within the document. (one-based)",
+      "type": "integer",
+      "minimum": 1
+    },
+    "attributes": {
+      "description": "List of attributes captured about the named element from its configuration.",
+      "type": ["array", "null"],
+      "items": {
+        "description": "Individual attribute information about the named element, derived from its configuration.",
+        "type": "object",
+        "required": ["source", "attribute", "value"],
+        "properties": {
+          "source": {
+            "description": "The type of configuration, and source of its value.",
+            "enum": ["callback", "content", "selector", "dataset", "attributes", "properties", "child_text", "error"],
+            "maxLength": 40
+          },
+          "attribute": {
+            "description": "The name of an attribute captured by the configuration.",
+            "type": "string",
+            "maxLength": 255
+          },
+          "value": {
+            "description": "The value for the attribute captured by this configuration.",
+            "type": "string",
+            "maxLength": 2048
+          }
+        }
+      }
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": ["element_name", "height", "width", "position_x", "position_y"],
+  "self": {
+    "vendor": "com.snowplowanalytics.snowplow",
+    "name": "element",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#"
+}

--- a/schemas/com.snowplowanalytics.snowplow/element_content/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.snowplow/element_content/jsonschema/1-0-0
@@ -1,0 +1,61 @@
+{
+  "description": "Entity describing the content of an element matching a named configuration.",
+  "properties": {
+    "parent_name": {
+      "description": "The name of the configuration for the element/component that contains the element described by this entity.",
+      "type": "string",
+      "maxLength": 255
+    },
+    "parent_index": {
+      "description": "The index of this element's parent element/component's within it's parent's other matches for it's element configuration.",
+      "type": "integer",
+      "minimum": 1
+    },
+    "element_name": {
+      "description": "The name of the configuration for the element/component that contains this data. This will usually match the corresponding element_name in an event payload or other entity.",
+      "type": "string",
+      "maxLength": 255
+    },
+    "element_index": {
+      "description": "The position of this element's within it's parent's other matches for the element's configuration.",
+      "type": "integer",
+      "minimum": 1
+    },
+    "attributes": {
+      "description": "Results of configured contents descriptions found on this element.",
+      "type": ["array", "null"],
+      "items": {
+        "description": "An individual contents description found on this element.",
+        "type": "object",
+        "required": ["source", "attribute", "value"],
+        "properties": {
+          "source": {
+            "description": "The type of content description that produced this result.",
+            "enum": ["callback", "content", "selector", "dataset", "attributes", "properties", "child_text", "error"],
+            "maxLength": 40
+          },
+          "attribute": {
+            "description": "The name of the discovered content attribute found.",
+            "type": "string",
+            "maxLength": 255
+          },
+          "value": {
+            "description": "The value of the discovered content attribute found.",
+            "type": "string",
+            "maxLength": 2048
+          }
+        }
+      }
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": ["parent_name", "parent_index", "element_name", "element_index"],
+  "self": {
+    "vendor": "com.snowplowanalytics.snowplow",
+    "name": "element_content",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#"
+}

--- a/schemas/com.snowplowanalytics.snowplow/element_statistics/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.snowplow/element_statistics/jsonschema/1-0-0
@@ -1,0 +1,86 @@
+{
+  "description": "Entity detailing aggregate statistics for a named matched using the Element Tracking plugin.",
+  "properties": {
+    "element_name": {
+      "description": "The name of the element configuration that this entity is detailing.",
+      "type": "string",
+      "maxLength": 255
+    },
+    "element_index": {
+      "description": "The (1-based) index of the element amongst the `element_matches` elements that match its same configuration.",
+      "type": "number",
+      "minimum": 1
+    },
+    "element_matches": {
+      "description": "The count of the elements that matched the configuration named `element_name`.",
+      "type": "number",
+      "minimum": 0
+    },
+    "current_state": {
+      "description": "The visibility state of the element at the time of this event.",
+      "type": "string",
+      "maxLength": 40
+    },
+    "min_size": {
+      "description": "The smallest dimensions observed of the named element, in virtual pixels. (width x height)",
+      "type": "string",
+      "pattern": "^[0-9.]+x[0-9.]+$",
+      "maxLength": 40
+    },
+    "current_size": {
+      "description": "The current dimensions observed of the named element, in virtual pixels. (width x height)",
+      "type": "string",
+      "pattern": "^[0-9.]+x[0-9.]+$",
+      "maxLength": 40
+    },
+    "max_size": {
+      "description": "The largest dimensions observed of the named element, in virtual pixels. (width x height)",
+      "type": "string",
+      "pattern": "^[0-9.]+x[0-9.]+$",
+      "maxLength": 40
+    },
+    "y_depth_ratio": {
+      "description": "The maximum vertical position seen of the element at the time of the event, expressed as a ratio of its height; from 0.0 - 1.0 (e.g. 0% - 100%).",
+      "type": ["number", "null"],
+      "minimum": 0.0,
+      "maximum": 1.0
+    },
+    "max_y_depth_ratio": {
+      "description": "The maximum vertical position seen of the element so far, expressed as a ratio of its height at the time; from 0.0 - 1.0 (e.g. 0% - 100%).",
+      "type": ["number", "null"],
+      "minimum": 0.0,
+      "maximum": 1.0
+    },
+    "max_y_depth": {
+      "description": "The maximum vertical position seen of the element so far, as a fraction.",
+      "type": "string",
+      "pattern": "^[0-9.]+/[0-9.]+$",
+      "maxLength": 40
+    },
+    "element_age_ms": {
+      "description": "The amount of time (in milliseconds) this element has existed on page since it was first observed.",
+      "type": "integer",
+      "minimum": 0
+    },
+    "times_in_view": {
+      "description": "The amount of times this element has appeared in view.",
+      "type": "integer",
+      "minimum": 0
+    },
+    "total_time_visible_ms": {
+      "description": "The cumulative amount of time (in milliseconds) this element has been in view so far.",
+      "type": "integer",
+      "minimum": 0
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": ["element_name", "min_size", "max_size", "max_y_depth_ratio", "max_y_depth", "element_age_ms", "times_in_view", "total_time_visible_ms"],
+  "self": {
+    "vendor": "com.snowplowanalytics.snowplow",
+    "name": "element_statistics",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#"
+}

--- a/schemas/com.snowplowanalytics.snowplow/expose_element/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.snowplow/expose_element/jsonschema/1-0-0
@@ -1,0 +1,20 @@
+{
+  "description": "Event that fires when an element matching a named configuration is detected as intersecting with the viewport, becoming visible to the user.",
+  "properties": {
+    "element_name": {
+      "description": "The name of the element that was exposed. Should match the element name field in entities that describe this particular element.",
+      "type": "string",
+      "maxLength": 255
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": ["element_name"],
+  "self": {
+    "vendor": "com.snowplowanalytics.snowplow",
+    "name": "expose_element",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#"
+}

--- a/schemas/com.snowplowanalytics.snowplow/obscure_element/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.snowplow/obscure_element/jsonschema/1-0-0
@@ -1,0 +1,20 @@
+{
+  "description": "Event that fires when an element matching a named configuration is detected as becoming hidden from a user or moving out of the viewport.",
+  "properties": {
+    "element_name": {
+      "description": "The name of the element that was obscured. Should match the element name field in entities that describe this particular element.",
+      "type": "string",
+      "maxLength": 255
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": ["element_name"],
+  "self": {
+    "vendor": "com.snowplowanalytics.snowplow",
+    "name": "obscure_element",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#"
+}


### PR DESCRIPTION
This PR adds schemas for a new [Element Tracking plugin](https://github.com/snowplow/snowplow-javascript-tracker/pull/1400) for the JavaScript Tracker.

It contains 4 Self Describing Events:
- `create_element`
- `destroy_element`
- `expose_element`
- `obscure_element`

And 4 entities:
- `element`
- `element_content`
- `element_statistics`
- `component_parents`
