### PR TITLE
Add com.snowplowanalytics.snowplow/button_click/jsonschema/2-0-0

### DIFF
--- a/schemas/com.snowplowanalytics.snowplow/button_click/jsonschema/1-0-1
+++ b/schemas/com.snowplowanalytics.snowplow/button_click/jsonschema/1-0-1
@@ -1,0 +1,53 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Schema for a button click event",
+  "self": {
+    "vendor": "com.snowplowanalytics.snowplow",
+    "name": "button_click",
+    "format": "jsonschema",
+    "version": "1-0-1"
+  },
+  "type": "object",
+  "properties": {
+    "label": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "The text on the button clicked, or a user-provided override",
+      "minLength": 1,
+      "maxLength": 4096
+    },
+    "id": {
+      "description": "The ID of the button clicked, if present",
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 4096
+    },
+    "classes": {
+      "description": "An array of class names from the button clicked",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": "string",
+        "maxLength": 4096
+      }
+    },
+    "name": {
+      "description": "The name of the button, if present",
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 4096
+    }
+  },
+  "additionalProperties": false,
+  "$supersedes": [
+    "1-0-0"
+  ]
+}

--- a/schemas/com.snowplowanalytics.snowplow/button_click/jsonschema/2-0-0
+++ b/schemas/com.snowplowanalytics.snowplow/button_click/jsonschema/2-0-0
@@ -5,7 +5,7 @@
     "vendor": "com.snowplowanalytics.snowplow",
     "name": "button_click",
     "format": "jsonschema",
-    "version": "1-0-1"
+    "version": "2-0-0"
   },
   "type": "object",
   "properties": {


### PR DESCRIPTION
This PR makes the `label` property of the `button_click` schema an optional property. This is to handle buttons without any inner text - for example icon buttons.

I've also added the $supersedes property for the previous v1-0-0 schema