### PR TITLE
Add 2-0-0 identity schemas with snake_case field names

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+Release 180 (2026-03-30)
+------------------------
+Add com.snowplowanalytics.snowplow/identity_merge/jsonschema/2-0-0 (#1476)
+Add com.snowplowanalytics.snowplow/identity/jsonschema/2-0-0 (#1476)
+
 Release 179 (2026-03-23)
 ------------------------
 Add com.snowplowanalytics.snowplow.enrichments/bot_detection_enrichment_config/jsonschema/1-0-1 (#1472)

--- a/schemas/com.snowplowanalytics.snowplow/identity/jsonschema/2-0-0
+++ b/schemas/com.snowplowanalytics.snowplow/identity/jsonschema/2-0-0
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "type": "object",
+  "self": {
+    "vendor": "com.snowplowanalytics.snowplow",
+    "name": "identity",
+    "format": "jsonschema",
+    "version": "2-0-0"
+  },
+  "description": "Identity context that is enriched onto events by Snowplow Identities",
+  "properties": {
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "snowplow_id": {
+      "type": "string",
+      "maxLength": 29,
+      "pattern": "^sp_[A-Za-z2-7]{26}$"
+    }
+  },
+  "required": ["snowplow_id", "created_at"],
+  "additionalProperties": false
+}

--- a/schemas/com.snowplowanalytics.snowplow/identity_merge/jsonschema/2-0-0
+++ b/schemas/com.snowplowanalytics.snowplow/identity_merge/jsonschema/2-0-0
@@ -1,0 +1,66 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "type": "object",
+  "self": {
+    "vendor": "com.snowplowanalytics.snowplow",
+    "name": "identity_merge",
+    "format": "jsonschema",
+    "version": "2-0-0"
+  },
+  "description": "Event emitted when Snowplow Identities merges user identities",
+  "properties": {
+    "merged": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "snowplow_id",
+          "created_at",
+          "merged_at",
+          "triggering_event_id"
+        ],
+        "properties": {
+          "merged_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "snowplow_id": {
+            "type": "string",
+            "maxLength": 29,
+            "pattern": "^sp_[A-Za-z2-7]{26}$"
+          },
+          "triggering_event_id": {
+            "type": "string",
+            "maxLength": 36
+          }
+        },
+        "additionalProperties": false
+      },
+      "description": "Detailed info about merged identities"
+    },
+    "merges": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "List of merged identity IDs"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "When the parent identity was created"
+    },
+    "snowplow_id": {
+      "description": "The parent/surviving identity ID",
+      "type": "string",
+      "maxLength": 29,
+      "pattern": "^sp_[A-Za-z2-7]{26}$"
+    }
+  },
+  "required": ["snowplow_id", "created_at", "merges", "merged"],
+  "additionalProperties": false
+}


### PR DESCRIPTION
Previously identity and identity_merge schemas used camelCase field names (snowplowId, createdAt, mergedAt, triggeringEventId) in their 1-0-0 versions.

Now 2-0-0 versions use snake_case field names (snowplow_id, created_at, merged_at, triggering_event_id) to align with Snowplow conventions. The 1-0-0 schemas remain unchanged for backward compatibility.