### PR TITLE
Added event_specification_validation schema for enrich

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Release 183 (2026-04-23)
+------------------------
+Add com.snowplowanalytics.snowplow/event_specification_validation/jsonschema/1-0-0 (#1481)
+
 Release 182 (2026-04-20)
 ------------------------
 Add com.optimizely.optimizelyx/summary/jsonschema/1-1-0 (#1483)

--- a/schemas/com.snowplowanalytics.snowplow/event_specification_validation/jsonschema/1-0-0
+++ b/schemas/com.snowplowanalytics.snowplow/event_specification_validation/jsonschema/1-0-0
@@ -1,0 +1,40 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "self": {
+    "vendor": "com.snowplowanalytics.snowplow",
+    "name": "event_specification_validation",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "description": "Validation result for an event against its declared event specification version.",
+  "type": "object",
+  "properties": {
+    "isValid": {
+      "type": "boolean",
+      "description": "Whether the event passed validation against its event specification."
+    },
+    "errors": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "Human-readable error description."
+          },
+          "schema": {
+            "type": ["string", "null"],
+            "description": "Iglu schema URI of the entity or event that caused the error."
+          },
+          "path": {
+            "type": ["string", "null"],
+            "description": "JSON path to the property that failed validation."
+          }
+        },
+        "required": ["message"]
+      },
+      "description": "A list of validation errors."
+    }
+  },
+  "required": ["isValid"]
+}


### PR DESCRIPTION
Summary                                                                                                                                                                                        
                                                                                                                                                                                                 
  - Adds com.snowplowanalytics.snowplow/event_specification_validation/jsonschema/1-0-0
                                                                                                                                                                                                 
  Context                                                                                                                

  This schema defines a context entity that enrich attaches to events during event specification validation. Initially it will only be attached when validation fails, but we want to keep the door open to also attach it on passed validations without requiring a major version bump.
                                                                                                                                                                                                 
  This is reflected in the design:                                                                                       
  - isValid is a required boolean flag, so the entity can represent both outcomes
  - errors is optional, so it can be omitted entirely in the pass case                                                                                                                           
                                                                      
  The errors array items are intentionally unconstrained ("type": "object" with no required properties). This follows the precedent set by the existing failure schema, which documents expected fields in the description but does not enforce them in the schema itself. 