### PR TITLE
Add com.optimizely.optimizelyx/summary/jsonschema/1-1-0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Release 182 (2026-04-20)
+------------------------
+Add com.optimizely.optimizelyx/summary/jsonschema/1-1-0 (#1483)
+
 Release 181 (2026-04-15)
 ------------------------
 Add com.iterable/system_webhook/jsonschema/2-0-1 (#1480)

--- a/schemas/com.optimizely.optimizelyx/summary/jsonschema/1-1-0
+++ b/schemas/com.optimizely.optimizelyx/summary/jsonschema/1-1-0
@@ -1,0 +1,42 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Context for an active Optimizely X campaign on the page. One entry per active campaign; covers both Web Experimentation and Personalization.",
+  "self": {
+    "vendor": "com.optimizely.optimizelyx",
+    "name": "summary",
+    "format": "jsonschema",
+    "version": "1-1-0"
+  },
+  "type": "object",
+  "properties": {
+    "campaignId": {
+      "description": "Optimizely campaign (layer) ID. For Personalization, the parent campaign containing the experience.",
+      "type": ["integer", "null"],
+      "minimum": 0,
+      "maximum": 9223372036854775807
+    },
+    "experimentId": {
+      "description": "Active experiment ID, or experience ID for Personalization campaigns.",
+      "type": ["integer", "null"],
+      "minimum": 0,
+      "maximum": 9223372036854775807
+    },
+    "variationName": {
+      "description": "Name of the assigned variation as configured in Optimizely.",
+      "type": ["string", "null"],
+      "maxLength": 255
+    },
+    "variation": {
+      "description": "ID of the assigned variation.",
+      "type": ["integer", "null"],
+      "minimum": 0,
+      "maximum": 9223372036854775807
+    },
+    "visitorId": {
+      "description": "Optimizely visitor ID used for bucketing.",
+      "type": ["string", "null"],
+      "maxLength": 100
+    }
+  },
+  "additionalProperties": true
+}


### PR DESCRIPTION
## Summary

Adds schema version `1-1-0` of `com.optimizely.optimizelyx/summary`, introducing an optional `campaignId` field.

## Why

The `browser-plugin-optimizely-x` plugin in [snowplow/snowplow-javascript-tracker#1463](https://github.com/snowplow/snowplow-javascript-tracker/pull/1463) switches from `getActiveExperimentIds()` to `getCampaignStates({ isActive: true })` to correctly capture the campaign layer for Optimizely Personalization campaigns, which was previously dropped entirely. The tracker PR emits events against this new schema version.

## Changes vs 1-0-0

- Adds optional `campaignId` (`integer | null`, same bounds as other IDs).
- All existing fields unchanged.

## SchemaVer bump

REVISION (`1-0-0` → `1-1-0`). The base schema has `additionalProperties: true`, so per [SchemaVer rules](https://docs.snowplow.io/docs/api-reference/iglu/common-architecture/schemaver/) adding an optional property is a REVISION rather than an ADDITION — historical events could have carried a conflicting `campaignId` via the open map.

## Compatibility

`campaignId` is optional, so existing `1-0-0` events remain valid under `1-1-0`.