### PR TITLE
Add com.snowplowanalytics.snowplow/identity/jsonschema/2-0-1

### DIFF
--- a/schemas/com.snowplowanalytics.snowplow/identity/jsonschema/2-0-1
+++ b/schemas/com.snowplowanalytics.snowplow/identity/jsonschema/2-0-1
@@ -1,0 +1,31 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "type": "object",
+  "self": {
+    "vendor": "com.snowplowanalytics.snowplow",
+    "name": "identity",
+    "format": "jsonschema",
+    "version": "2-1-0"
+  },
+  "description": "Identity context that is enriched onto events by Snowplow Identities",
+  "properties": {
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "snowplow_id": {
+      "type": "string",
+      "maxLength": 29,
+      "pattern": "^sp_[A-Za-z2-7]{26}$"
+    },
+    "decision_reasons": {
+      "description": "Why the service made this decision. Absent when there is nothing to report.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "required": ["snowplow_id", "created_at"],
+  "additionalProperties": false
+}


### PR DESCRIPTION
[ISP-279](https://snplow.atlassian.net/browse/ISP-279) (parent: [ISP-278](https://snplow.atlassian.net/browse/ISP-278))

## Summary

Adds schema version `2-1-0` of `com.snowplowanalytics.snowplow/identity`, introducing an optional `decision_reasons` field that reports why Snowplow Identities made a decision for the event (for example, refusing a merge because the identity is at its merge limit). The warehouse models use it to label a split identifier and prefer the correct identity.

## Changes vs 2-0-0

- Adds optional `decision_reasons`: array of strings. The set of reason codes is owned by the service and is deliberately not enumerated in the schema, so new reasons can be added without a schema change. Omitted entirely when there is nothing to report; never `null`.
- `required` and `additionalProperties: false` unchanged. All existing fields unchanged.

## SchemaVer bump

ADDITION (`2-0-0` → `2-1-0`). The base schema has `additionalProperties: false`, so adding an optional property is an ADDITION per [SchemaVer rules](https://docs.snowplow.io/docs/api-reference/iglu/common-architecture/schemaver/). Stays in MODEL 2, so it lands in the existing `contexts_com_snowplowanalytics_snowplow_identity_2` column.

## Compatibility

`decision_reasons` is optional, so existing `2-0-0` events remain valid under `2-1-0`. This schema must be published before Enrich emits against it.

## Related

- Snowplow Identities and Enrich changes to follow under ISP-278 (this schema ships first).

[ISP-279]: https://snplow.atlassian.net/browse/ISP-279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ISP-278]: https://snplow.atlassian.net/browse/ISP-278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ